### PR TITLE
Scope window and reload state per WebSocket connection

### DIFF
--- a/packages/server/src/mcp/action-emitter.ts
+++ b/packages/server/src/mcp/action-emitter.ts
@@ -80,7 +80,8 @@ class ActionEmitter extends EventEmitter {
    * Emit an OS Action to all listeners.
    */
   emitAction(action: OSAction, sessionId?: string, agentId?: string): void {
-    this.emit('action', { action, sessionId, agentId } as ActionEvent);
+    const currentAgentId = agentId ?? getAgentId();
+    this.emit('action', { action, sessionId, agentId: currentAgentId } as ActionEvent);
   }
 
   /**

--- a/packages/server/src/mcp/index.ts
+++ b/packages/server/src/mcp/index.ts
@@ -19,7 +19,7 @@ export {
 } from './action-emitter.js';
 
 // Window state
-export { windowState, type WindowState } from './window-state.js';
+export { windowStateRegistryManager, WindowStateRegistry, type WindowState } from './window-state.js';
 
 // Utils
 export { ok, okWithImages } from './utils.js';

--- a/packages/server/src/mcp/tools/index.ts
+++ b/packages/server/src/mcp/tools/index.ts
@@ -12,7 +12,9 @@ import { registerHttpTools } from './http.js';
 import { registerAppDevTools } from './app-dev.js';
 import { registerSandboxTools } from './sandbox.js';
 import { registerReloadTools } from '../../reload/tools.js';
-import { reloadCache } from '../../reload/index.js';
+import { reloadCacheManager } from '../../reload/index.js';
+import { windowStateRegistryManager } from '../window-state.js';
+import { getCurrentConnectionId } from '../../agents/session.js';
 
 export { registerSystemTools } from './system.js';
 export { registerWindowTools } from './window.js';
@@ -26,14 +28,18 @@ export { registerSandboxTools } from './sandbox.js';
  * Register all YAAR tools on their respective MCP servers.
  */
 export function registerAllTools(servers: Record<McpServerName, McpServer>): void {
+  const resolveConnectionId = () => getCurrentConnectionId() ?? 'global';
+  const getWindowState = () => windowStateRegistryManager.get(resolveConnectionId());
+  const getReloadCache = () => reloadCacheManager.get(resolveConnectionId());
+
   registerSystemTools(servers.system);
   registerHttpTools(servers.system);
   registerSandboxTools(servers.system);
-  registerWindowTools(servers.window);
+  registerWindowTools(servers.window, getWindowState);
   registerStorageTools(servers.storage);
   registerAppsTools(servers.apps);
   registerAppDevTools(servers.apps);
-  registerReloadTools(servers.system, reloadCache);
+  registerReloadTools(servers.system, getReloadCache, getWindowState);
 }
 
 /**

--- a/packages/server/src/mcp/tools/window.ts
+++ b/packages/server/src/mcp/tools/window.ts
@@ -15,7 +15,7 @@ import {
   componentSchema,
 } from '@yaar/shared';
 import { actionEmitter } from '../action-emitter.js';
-import { windowState } from '../window-state.js';
+import type { WindowStateRegistry } from '../window-state.js';
 import { ok, okWithImages } from '../utils.js';
 
 const gapEnum = z.enum(['none', 'sm', 'md', 'lg']);
@@ -34,7 +34,7 @@ const colsSchema = z.union([
   }).pipe(colsInner),
 ]);
 
-export function registerWindowTools(server: McpServer): void {
+export function registerWindowTools(server: McpServer, getWindowState: () => WindowStateRegistry): void {
   // create_window - for display content (markdown, html, text, iframe)
   server.registerTool(
     'create',
@@ -339,7 +339,7 @@ export function registerWindowTools(server: McpServer): void {
         'List all windows currently open on the YAAR desktop. Returns window IDs, titles, positions, sizes, and lock status.',
     },
     async () => {
-      const windows = windowState.listWindows();
+      const windows = getWindowState().listWindows();
 
       if (windows.length === 0) {
         return ok('No windows are currently open.');
@@ -371,7 +371,7 @@ export function registerWindowTools(server: McpServer): void {
       },
     },
     async (args) => {
-      const win = windowState.getWindow(args.windowId);
+      const win = getWindowState().getWindow(args.windowId);
 
       if (!win) {
         return ok(`Window "${args.windowId}" not found. Use list to see available windows.`);

--- a/packages/server/src/tests/connection-scoped-state.test.ts
+++ b/packages/server/src/tests/connection-scoped-state.test.ts
@@ -1,0 +1,111 @@
+import { windowStateRegistryManager } from '../mcp/window-state.js'
+import { reloadCacheManager } from '../reload/index.js'
+import type { Fingerprint } from '../reload/types.js'
+import type { OSAction } from '@yaar/shared'
+
+describe('connection-scoped state', () => {
+  const connA = 'conn-a'
+  const connB = 'conn-b'
+
+  afterEach(() => {
+    windowStateRegistryManager.clearAll()
+    reloadCacheManager.clearAll()
+  })
+
+  it('isolates window state across two connections', () => {
+    const stateA = windowStateRegistryManager.get(connA)
+    const stateB = windowStateRegistryManager.get(connB)
+
+    stateA.handleAction({
+      type: 'window.create',
+      windowId: 'a-win',
+      title: 'A Window',
+      bounds: { x: 0, y: 0, w: 400, h: 300 },
+      content: { renderer: 'markdown', data: 'A' },
+    })
+
+    stateB.handleAction({
+      type: 'window.create',
+      windowId: 'b-win',
+      title: 'B Window',
+      bounds: { x: 10, y: 10, w: 400, h: 300 },
+      content: { renderer: 'markdown', data: 'B' },
+    })
+
+    expect(stateA.hasWindow('a-win')).toBe(true)
+    expect(stateA.hasWindow('b-win')).toBe(false)
+    expect(stateB.hasWindow('b-win')).toBe(true)
+    expect(stateB.hasWindow('a-win')).toBe(false)
+  })
+
+  it('isolates reload cache entries across two connections', () => {
+    const cacheA = reloadCacheManager.get(connA)
+    const cacheB = reloadCacheManager.get(connB)
+
+    const fingerprint: Fingerprint = {
+      triggerType: 'main',
+      ngrams: ['open', 'app'],
+      contentHash: 'same-content',
+      windowStateHash: 'same-windows',
+    }
+
+    const actions: OSAction[] = [
+      {
+        type: 'window.create',
+        windowId: 'shared-window-id',
+        title: 'Shared',
+        bounds: { x: 0, y: 0, w: 200, h: 200 },
+        content: { renderer: 'markdown', data: 'hello' },
+      },
+    ]
+
+    cacheA.record(fingerprint, actions, 'entry A')
+    cacheB.record(fingerprint, actions, 'entry B')
+
+    expect(cacheA.listEntries()).toHaveLength(1)
+    expect(cacheB.listEntries()).toHaveLength(1)
+    expect(cacheA.listEntries()[0]?.label).toBe('entry A')
+    expect(cacheB.listEntries()[0]?.label).toBe('entry B')
+  })
+
+  it('clearing one connection does not clear the other', () => {
+    const stateA = windowStateRegistryManager.get(connA)
+    const stateB = windowStateRegistryManager.get(connB)
+    const cacheA = reloadCacheManager.get(connA)
+    const cacheB = reloadCacheManager.get(connB)
+
+    stateA.handleAction({
+      type: 'window.create',
+      windowId: 'a-win',
+      title: 'A Window',
+      bounds: { x: 0, y: 0, w: 400, h: 300 },
+      content: { renderer: 'markdown', data: 'A' },
+    })
+    stateB.handleAction({
+      type: 'window.create',
+      windowId: 'b-win',
+      title: 'B Window',
+      bounds: { x: 10, y: 10, w: 400, h: 300 },
+      content: { renderer: 'markdown', data: 'B' },
+    })
+
+    cacheA.record(
+      { triggerType: 'main', ngrams: ['a'], contentHash: 'a', windowStateHash: 'a' },
+      [],
+      'A only'
+    )
+    cacheB.record(
+      { triggerType: 'main', ngrams: ['b'], contentHash: 'b', windowStateHash: 'b' },
+      [],
+      'B only'
+    )
+
+    windowStateRegistryManager.clear(connA)
+    reloadCacheManager.clear(connA)
+
+    expect(windowStateRegistryManager.get(connA).listWindows()).toHaveLength(0)
+    expect(windowStateRegistryManager.get(connB).listWindows()).toHaveLength(1)
+    expect(reloadCacheManager.get(connA).listEntries()).toHaveLength(0)
+    expect(reloadCacheManager.get(connB).listEntries()).toHaveLength(1)
+  })
+})

--- a/packages/server/src/websocket/server.ts
+++ b/packages/server/src/websocket/server.ts
@@ -5,6 +5,7 @@
 import type { Server } from 'http';
 import { WebSocketServer, WebSocket } from 'ws';
 import { SessionManager } from '../agents/index.js';
+import { windowStateRegistryManager } from '../mcp/window-state.js';
 import { getWarmPool } from '../providers/factory.js';
 import { getBroadcastCenter, generateConnectionId } from '../events/broadcast-center.js';
 import type { ClientEvent, ServerEvent, OSAction } from '@yaar/shared';
@@ -31,6 +32,12 @@ export function createWebSocketServer(
     broadcastCenter.subscribe(connectionId, ws);
 
     const manager = new SessionManager(connectionId, options.contextMessages);
+
+    const windowState = windowStateRegistryManager.get(connectionId);
+    if (options.restoreActions.length > 0) {
+      windowState.restoreFromActions(options.restoreActions);
+    }
+
 
     // Track initialization state and queue early messages
     let initialized = false;


### PR DESCRIPTION
### Motivation
- Prevent cross-connection interference by removing process-global window and reload state and scoping both to a stable connection/session key (`ConnectionId`).
- Provide a clear lifecycle for per-connection state so disconnect/reset only affects that connection and reload cache invalidation is accurate.

### Description
- Introduced connection-keyed registries: `WindowStateRegistryManager.get(connectionId)` and `ReloadCacheManager` (`reloadCacheManager.get` / `ensureLoaded`) and replaced global singletons with these managers (`packages/server/src/mcp/window-state.ts`, `packages/server/src/reload/index.ts`).
- Threaded scoped instances through orchestration: `SessionManager` now resolves per-connection `windowState` and `reloadCache` and passes them into `ContextPool` instead of importing globals; `ContextPool` now uses injected `windowState`/`reloadCache` (several changes under `packages/server/src/agents/*`).
- Updated MCP tool registration and tools to resolve scoped state at call time (via the current agent async context): window tools and reload tools accept accessors instead of importing process-global state (`packages/server/src/mcp/tools/*`, `packages/server/src/reload/tools.ts`).
- Ensured action routing uses agent→connection mapping by including the agent id in emitted actions by default (`actionEmitter.emitAction`), and wired lifecycle/cleanup so only a connection's registries are cleared on disconnect/reset; applied restore actions per-connection during websocket connect (`packages/server/src/mcp/action-emitter.ts`, `packages/server/src/websocket/server.ts`, `packages/server/src/lifecycle.ts`).
- Added a test `packages/server/src/tests/connection-scoped-state.test.ts` verifying two simulated connections create windows and cache entries concurrently with no cross-visibility and that clearing one connection doesn't affect the other.

### Testing
- Ran unit tests with `pnpm --filter @yaar/server test` and all server tests passed (`33 tests` in this environment), including the new `connection-scoped-state.test.ts` (✅).
- Ran `pnpm --filter @yaar/server typecheck` in this environment which reported failures due to unresolved workspace package `@yaar/shared` (environment-specific package resolution issue) and is unrelated to the scoped-state refactor (⚠️).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698467a41f7c832885684ad02fbbf42e)