### PR TITLE
Add reference docs for OS Actions, App Protocol, and Storage API

### DIFF
--- a/docs/app_protocol_reference.md
+++ b/docs/app_protocol_reference.md
@@ -1,0 +1,341 @@
+# App Protocol Reference
+
+The App Protocol enables bidirectional communication between AI agents and iframe-based apps. Apps register a self-describing manifest of their capabilities (state keys and commands), and agents discover and interact with them at runtime.
+
+**Source:** `packages/shared/src/app-protocol.ts`
+
+---
+
+## Overview
+
+```
+Agent calls MCP tool (app_query / app_command)
+  → ActionEmitter → WebSocket → Frontend
+  → postMessage → Iframe App
+  → postMessage response → Frontend
+  → WebSocket → ActionEmitter resolves
+  → MCP tool returns result to agent
+```
+
+An app opts in by setting `"appProtocol": true` in its `app.json` and calling `window.yaar.app.register()` inside the iframe.
+
+---
+
+## MCP Tools
+
+**Source:** `packages/server/src/mcp/window/app-protocol.ts`
+
+### `app_query`
+
+Read state from an iframe app or discover its capabilities.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `windowId` | `string` | yes | Window containing the iframe app |
+| `stateKey` | `string` | yes | State key to read. Use `"manifest"` to discover all keys and commands. |
+
+**Behavior:**
+1. Validates the window exists and uses the `iframe` renderer.
+2. Waits up to 5 s for the app to send `yaar:app-ready` (skipped if already registered).
+3. Sends the request through the protocol pipeline.
+4. Returns the JSON response or an error string.
+
+**Returns (manifest):** JSON-stringified `AppManifest` describing available state keys and commands.
+**Returns (state key):** JSON-stringified value from the app's state handler.
+
+### `app_command`
+
+Execute a command on an iframe app.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `windowId` | `string` | yes | Window containing the iframe app |
+| `command` | `string` | yes | Command name (e.g., `"setCells"`, `"addItem"`) |
+| `params` | `Record<string, unknown>` | no | Parameters as described in the manifest |
+
+**Behavior:**
+1. Same validation and readiness check as `app_query`.
+2. Sends the command through the protocol pipeline.
+3. Records the command via `WindowStateRegistry.recordAppCommand()` for replay on reload.
+4. Returns the JSON result or an error string.
+
+---
+
+## Manifest
+
+An `AppManifest` describes what the app can do. The agent retrieves it by calling `app_query(windowId, "manifest")`.
+
+```typescript
+interface AppManifest {
+  appId: string;
+  name: string;
+  state: Record<string, AppStateDescriptor>;
+  commands: Record<string, AppCommandDescriptor>;
+}
+
+interface AppStateDescriptor {
+  description: string;
+  schema?: object;        // JSON Schema (optional)
+}
+
+interface AppCommandDescriptor {
+  description: string;
+  params?: object;        // JSON Schema for parameters (optional)
+  returns?: object;       // JSON Schema for return value (optional)
+}
+```
+
+The manifest is built automatically from the registration config by stripping handler functions and exposing only descriptions and schemas.
+
+---
+
+## PostMessage Protocol
+
+These messages are exchanged between the frontend (parent window) and the iframe app via `postMessage()`.
+
+### Manifest
+
+**Request** (parent → iframe):
+```json
+{ "type": "yaar:app-manifest-request", "requestId": "req-..." }
+```
+
+**Response** (iframe → parent):
+```json
+{
+  "type": "yaar:app-manifest-response",
+  "requestId": "req-...",
+  "manifest": { "appId": "...", "name": "...", "state": {}, "commands": {} },
+  "error": null
+}
+```
+
+### Query
+
+**Request** (parent → iframe):
+```json
+{ "type": "yaar:app-query-request", "requestId": "req-...", "stateKey": "items" }
+```
+
+**Response** (iframe → parent):
+```json
+{ "type": "yaar:app-query-response", "requestId": "req-...", "data": [...], "error": null }
+```
+
+### Command
+
+**Request** (parent → iframe):
+```json
+{
+  "type": "yaar:app-command-request",
+  "requestId": "req-...",
+  "command": "addItem",
+  "params": { "text": "Hello" }
+}
+```
+
+**Response** (iframe → parent):
+```json
+{ "type": "yaar:app-command-response", "requestId": "req-...", "result": { "ok": true }, "error": null }
+```
+
+---
+
+## WebSocket Events
+
+### Server → Client: `APP_PROTOCOL_REQUEST`
+
+```typescript
+{
+  type: 'APP_PROTOCOL_REQUEST';
+  requestId: string;
+  windowId: string;
+  request:
+    | { kind: 'manifest' }
+    | { kind: 'query'; stateKey: string }
+    | { kind: 'command'; command: string; params?: unknown };
+  seq?: number;
+}
+```
+
+### Client → Server: `APP_PROTOCOL_RESPONSE`
+
+```typescript
+{
+  type: 'APP_PROTOCOL_RESPONSE';
+  requestId: string;
+  windowId: string;
+  response:
+    | { kind: 'manifest'; manifest: AppManifest | null; error?: string }
+    | { kind: 'query'; data: unknown; error?: string }
+    | { kind: 'command'; result: unknown; error?: string };
+}
+```
+
+### Client → Server: `APP_PROTOCOL_READY`
+
+Sent when an iframe app calls `window.yaar.app.register()`.
+
+```typescript
+{
+  type: 'APP_PROTOCOL_READY';
+  windowId: string;
+}
+```
+
+---
+
+## Iframe SDK
+
+The SDK script (`IFRAME_APP_PROTOCOL_SCRIPT` in `packages/shared/src/app-protocol.ts`) is automatically injected into every iframe's `<head>` by the `IframeRenderer` component. It provides `window.yaar.app`.
+
+### `window.yaar.app.register(config)`
+
+Register the app with the protocol. Must be called once.
+
+```javascript
+window.yaar.app.register({
+  appId: 'my-app',
+  name: 'My App',
+
+  state: {
+    items: {
+      description: 'Current list of items',
+      schema: { type: 'array', items: { type: 'object' } },  // optional
+      handler: async () => {
+        return items;   // return current state
+      },
+    },
+  },
+
+  commands: {
+    addItem: {
+      description: 'Add a new item',
+      params: {
+        type: 'object',
+        properties: { text: { type: 'string' } },
+        required: ['text'],
+      },
+      handler: async (params) => {
+        items.push({ text: params.text });
+        render();
+        return { ok: true };
+      },
+    },
+  },
+});
+```
+
+On registration the SDK sends `{ type: 'yaar:app-ready', appId }` to the parent so the server knows the app supports the protocol.
+
+### `window.yaar.app.sendInteraction(description)`
+
+Send a free-form interaction message from the app to the AI agent. Useful for notifying the agent about user actions inside the iframe.
+
+```javascript
+window.yaar.app.sendInteraction('User clicked the save button');
+```
+
+This posts a `{ type: 'yaar:app-interaction', content: "..." }` message to the parent, which routes it to the window's agent.
+
+---
+
+## File Associations
+
+Apps can declare file types they can open in `app.json`:
+
+```json
+{
+  "appProtocol": true,
+  "fileAssociations": [
+    { "extensions": [".csv", ".xlsx"], "command": "openFile", "paramKey": "content" }
+  ]
+}
+```
+
+```typescript
+interface FileAssociation {
+  extensions: string[];   // File extensions (e.g. [".pdf", ".txt"])
+  command: string;        // App protocol command to invoke
+  paramKey: string;       // Parameter key for the file content
+}
+```
+
+When a user opens a file with a matching extension, the agent sends an `app_command` with the specified `command` and the file content in the `paramKey` parameter.
+
+---
+
+## Server-Side Internals
+
+### ActionEmitter
+
+**Source:** `packages/server/src/mcp/action-emitter.ts`
+
+| Method | Description |
+|--------|-------------|
+| `emitAppProtocolRequest(windowId, request, timeoutMs)` | Sends a request through the pipeline and returns a promise that resolves with the response (or `undefined` on timeout). Default timeout: 5000 ms. |
+| `resolveAppProtocolResponse(requestId, response)` | Called when the frontend sends `APP_PROTOCOL_RESPONSE`. Resolves the corresponding pending promise. |
+| `waitForAppReady(windowId, timeoutMs)` | Waits for `APP_PROTOCOL_READY` from the frontend. Returns `true` if the app registered, `false` on timeout. |
+| `notifyAppReady(windowId)` | Marks a window as protocol-ready and resolves pending `waitForAppReady()` calls. |
+
+### WindowStateRegistry
+
+**Source:** `packages/server/src/mcp/window-state.ts`
+
+Tracks per-window protocol state:
+
+| Field | Description |
+|-------|-------------|
+| `appProtocol?: boolean` | Set to `true` once `APP_PROTOCOL_READY` is received. Cached to skip `waitForAppReady()` on subsequent calls. |
+| `appCommands?: AppProtocolRequest[]` | All commands executed on the app. Replayed if the app reloads. |
+
+### Command Replay
+
+When an iframe app reloads (e.g., due to HMR or navigation), the server detects a new `APP_PROTOCOL_READY` for a window that was already marked as ready. It then replays all recorded `appCommands` so the app returns to its previous state.
+
+---
+
+## Example
+
+A minimal spreadsheet app:
+
+```javascript
+// Inside the iframe
+const cells = {};
+
+window.yaar.app.register({
+  appId: 'sheet',
+  name: 'Sheet',
+  state: {
+    cells: {
+      description: 'All cell values keyed by address',
+      handler: () => ({ ...cells }),
+    },
+  },
+  commands: {
+    setCells: {
+      description: 'Set one or more cell values',
+      params: {
+        type: 'object',
+        properties: {
+          cells: { type: 'object', additionalProperties: { type: 'string' } },
+        },
+        required: ['cells'],
+      },
+      handler: (params) => {
+        Object.assign(cells, params.cells);
+        render();
+        return { ok: true, count: Object.keys(params.cells).length };
+      },
+    },
+  },
+});
+```
+
+Agent interaction:
+
+```
+app_query(windowId: "sheet", stateKey: "manifest")  → discover capabilities
+app_query(windowId: "sheet", stateKey: "cells")      → read current state
+app_command(windowId: "sheet", command: "setCells", params: { cells: { "A1": "100" } })
+```

--- a/docs/os_actions_reference.md
+++ b/docs/os_actions_reference.md
@@ -1,0 +1,505 @@
+# OS Actions Reference
+
+OS Actions are the JSON commands the AI emits to control the desktop. The frontend receives them via WebSocket (`ACTIONS` event) and applies them to create windows, display notifications, and manage the desktop surface.
+
+**Source:** `packages/shared/src/actions.ts`
+
+---
+
+## Window Actions
+
+### `window.create`
+
+Create a new window on the desktop.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `'window.create'` | yes | |
+| `windowId` | `string` | yes | Unique window identifier |
+| `title` | `string` | yes | Title displayed in the titlebar |
+| `bounds` | `WindowBounds` | yes | Position and size: `{ x, y, w, h }` |
+| `content` | `WindowContent` | yes | Content payload: `{ renderer, data }` |
+| `variant` | `'standard' \| 'widget' \| 'panel'` | no | Window layer (default: `'standard'`). Widgets sit below standard windows; panels are fixed-position. |
+| `dockEdge` | `'top' \| 'bottom'` | no | Dock edge for panel variant |
+| `frameless` | `boolean` | no | Hide the titlebar |
+| `windowStyle` | `Record<string, string \| number>` | no | Custom CSS styles on the window element |
+| `minimized` | `boolean` | no | Create in minimized state |
+| `requestId` | `string` | no | Tracking ID for iframe load feedback |
+
+**Behavior:**
+- Bounds are clamped to the viewport.
+- Variant determines z-order layer: panels are excluded from stacking, widgets stack below standard windows.
+- Standard windows steal focus on creation unless `minimized` is true.
+
+### `window.close`
+
+Close and remove a window.
+
+| Field | Type | Required |
+|-------|------|----------|
+| `type` | `'window.close'` | yes |
+| `windowId` | `string` | yes |
+
+If the closed window was focused, focus moves to the topmost remaining window.
+
+### `window.focus`
+
+Bring a window to the front.
+
+| Field | Type | Required |
+|-------|------|----------|
+| `type` | `'window.focus'` | yes |
+| `windowId` | `string` | yes |
+
+- Standard windows move to top of z-order.
+- Widgets move to top of the widget layer (still below standard).
+- Panels are unaffected.
+- Unminimizes the window if it was minimized.
+
+### `window.minimize`
+
+Hide a window from the viewport.
+
+| Field | Type | Required |
+|-------|------|----------|
+| `type` | `'window.minimize'` | yes |
+| `windowId` | `string` | yes |
+
+Widgets and panels cannot be minimized (no-op).
+
+### `window.maximize`
+
+Maximize a window to fill the viewport.
+
+| Field | Type | Required |
+|-------|------|----------|
+| `type` | `'window.maximize'` | yes |
+| `windowId` | `string` | yes |
+
+Previous bounds are saved for later restore.
+
+### `window.restore`
+
+Restore a maximized or minimized window to its previous state.
+
+| Field | Type | Required |
+|-------|------|----------|
+| `type` | `'window.restore'` | yes |
+| `windowId` | `string` | yes |
+
+- If maximized: restores to the saved `previousBounds`.
+- If minimized: makes the window visible again.
+
+### `window.move`
+
+Move a window.
+
+| Field | Type | Required |
+|-------|------|----------|
+| `type` | `'window.move'` | yes |
+| `windowId` | `string` | yes |
+| `x` | `number` | yes |
+| `y` | `number` | yes |
+
+### `window.resize`
+
+Resize a window.
+
+| Field | Type | Required |
+|-------|------|----------|
+| `type` | `'window.resize'` | yes |
+| `windowId` | `string` | yes |
+| `w` | `number` | yes |
+| `h` | `number` | yes |
+
+### `window.setTitle`
+
+Change a window's title.
+
+| Field | Type | Required |
+|-------|------|----------|
+| `type` | `'window.setTitle'` | yes |
+| `windowId` | `string` | yes |
+| `title` | `string` | yes |
+
+### `window.setContent`
+
+Replace the entire content of a window.
+
+| Field | Type | Required |
+|-------|------|----------|
+| `type` | `'window.setContent'` | yes |
+| `windowId` | `string` | yes |
+| `content` | `WindowContent` | yes |
+
+Lock-protected: only the agent holding the lock can update a locked window.
+
+### `window.updateContent`
+
+Incrementally update window content with a diff operation.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `'window.updateContent'` | yes | |
+| `windowId` | `string` | yes | |
+| `operation` | `ContentUpdateOperation` | yes | See operations below |
+| `renderer` | `string` | no | Optionally change the renderer type |
+
+**ContentUpdateOperation variants:**
+
+| `op` | Fields | Valid renderers | Description |
+|------|--------|-----------------|-------------|
+| `'append'` | `data: string` | markdown, html, text | Append text to content |
+| `'prepend'` | `data: string` | markdown, html, text | Prepend text to content |
+| `'insertAt'` | `data: string`, `position: number` | markdown, html, text | Insert text at character position |
+| `'replace'` | `data: unknown` | all | Replace entire content data |
+| `'clear'` | — | all | Reset content to empty |
+
+Lock-protected.
+
+### `window.lock`
+
+Lock a window so only the specified agent can modify it.
+
+| Field | Type | Required |
+|-------|------|----------|
+| `type` | `'window.lock'` | yes |
+| `windowId` | `string` | yes |
+| `agentId` | `string` | yes |
+
+Other agents' `setContent` / `updateContent` calls will fail while locked.
+
+### `window.unlock`
+
+Release a window lock.
+
+| Field | Type | Required |
+|-------|------|----------|
+| `type` | `'window.unlock'` | yes |
+| `windowId` | `string` | yes |
+| `agentId` | `string` | yes |
+
+The `agentId` must match the agent that acquired the lock.
+
+### `window.capture`
+
+Capture a window's content as a PNG screenshot.
+
+| Field | Type | Required |
+|-------|------|----------|
+| `type` | `'window.capture'` | yes |
+| `windowId` | `string` | yes |
+| `requestId` | `string` | no |
+
+Async operation. For iframes, uses a three-tier strategy: (1) iframe self-capture via postMessage, (2) html2canvas on iframe content document, (3) html2canvas on the window frame. Returns base64 PNG via `RENDERING_FEEDBACK`.
+
+---
+
+## Notification Actions
+
+### `notification.show`
+
+Show a persistent notification.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `'notification.show'` | yes | |
+| `id` | `string` | yes | Unique notification ID |
+| `title` | `string` | yes | |
+| `body` | `string` | yes | |
+| `icon` | `string` | no | Icon name |
+| `duration` | `number` | no | Auto-dismiss after this many ms (persists until dismissed if omitted) |
+
+### `notification.dismiss`
+
+Dismiss a notification.
+
+| Field | Type | Required |
+|-------|------|----------|
+| `type` | `'notification.dismiss'` | yes |
+| `id` | `string` | yes |
+
+---
+
+## Toast Actions
+
+### `toast.show`
+
+Show a temporary toast message.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `'toast.show'` | yes | |
+| `id` | `string` | yes | Unique toast ID |
+| `message` | `string` | yes | |
+| `variant` | `'info' \| 'success' \| 'warning' \| 'error'` | no | Visual style (default: `'info'`) |
+| `action` | `{ label: string; eventId: string }` | no | Optional action button |
+| `duration` | `number` | no | Auto-dismiss timeout in ms |
+
+When the action button is clicked, the frontend sends a `TOAST_ACTION` event to the server with the `eventId`.
+
+### `toast.dismiss`
+
+Dismiss a toast.
+
+| Field | Type | Required |
+|-------|------|----------|
+| `type` | `'toast.dismiss'` | yes |
+| `id` | `string` | yes |
+
+---
+
+## Dialog Actions
+
+### `dialog.confirm`
+
+Show a modal confirmation dialog.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `'dialog.confirm'` | yes | |
+| `id` | `string` | yes | Unique dialog ID |
+| `title` | `string` | yes | |
+| `message` | `string` | yes | |
+| `confirmText` | `string` | no | Confirm button label (default: `'Yes'`) |
+| `cancelText` | `string` | no | Cancel button label (default: `'No'`) |
+| `permissionOptions` | `PermissionOptions` | no | Permission persistence config |
+
+**PermissionOptions:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `showRememberChoice` | `boolean` | Show "Remember my choice" checkbox |
+| `toolName` | `string` | Tool name for saving the decision |
+| `context` | `string?` | Optional context identifier |
+
+The user's response is sent back to the server as a `DIALOG_FEEDBACK` event. If `permissionOptions` is set and the user checks "remember", the decision is persisted to `config/permissions.json`.
+
+---
+
+## App Actions
+
+### `app.badge`
+
+Set a badge count on a desktop app icon.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `'app.badge'` | yes | |
+| `appId` | `string` | yes | App folder name in `apps/` |
+| `count` | `number` | yes | Badge count (0 clears the badge) |
+
+---
+
+## Desktop Actions
+
+### `desktop.refreshApps`
+
+Trigger a re-fetch of the app list from `GET /api/apps`.
+
+| Field | Type | Required |
+|-------|------|----------|
+| `type` | `'desktop.refreshApps'` | yes |
+
+### `desktop.createShortcut`
+
+Add a shortcut to the desktop.
+
+| Field | Type | Required |
+|-------|------|----------|
+| `type` | `'desktop.createShortcut'` | yes |
+| `shortcut` | `DesktopShortcut` | yes |
+
+**DesktopShortcut:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | Unique shortcut ID |
+| `label` | `string` | Display name |
+| `icon` | `string` | Emoji or image path |
+| `iconType` | `'emoji' \| 'image'` | Icon kind (optional) |
+| `type` | `'file' \| 'url' \| 'action'` | What the shortcut opens |
+| `target` | `string` | Storage path, URL, or action ID |
+| `createdAt` | `number` | Creation timestamp |
+
+### `desktop.removeShortcut`
+
+Remove a desktop shortcut.
+
+| Field | Type | Required |
+|-------|------|----------|
+| `type` | `'desktop.removeShortcut'` | yes |
+| `shortcutId` | `string` | yes |
+
+### `desktop.updateShortcut`
+
+Update fields on an existing shortcut.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `'desktop.updateShortcut'` | yes | |
+| `shortcutId` | `string` | yes | |
+| `updates` | `Partial<DesktopShortcut>` | yes | Partial fields to merge (excludes `id` and `createdAt`) |
+
+---
+
+## Window Content
+
+A `WindowContent` is `{ renderer: string; data: unknown }`. The `renderer` field selects how `data` is interpreted.
+
+| Renderer | `data` type | Description |
+|----------|-------------|-------------|
+| `'markdown'` | `string` | Markdown text |
+| `'html'` | `string` | Raw HTML |
+| `'text'` | `string` | Plain text |
+| `'table'` | `TableContentData` | Structured table |
+| `'iframe'` | `string \| IframeContentData` | Embedded iframe (URL string or object) |
+| `'component'` | `ComponentLayout` | Interactive UI components |
+
+**TableContentData:** `{ headers: string[]; rows: string[][] }`
+
+**IframeContentData:** `{ url: string; sandbox?: string }`
+
+### Component Layout
+
+```typescript
+{
+  components: Component[];  // Flat array, no nesting
+  cols?: number | number[]; // Grid columns: single number or ratio array (e.g. [8, 2])
+  gap?: 'none' | 'sm' | 'md' | 'lg';
+}
+```
+
+**Source:** `packages/shared/src/components.ts`
+
+#### Component Types
+
+**button**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `'button'` | yes | |
+| `label` | `string` | yes | Button text |
+| `action` | `string` | yes | Message sent to agent on click |
+| `variant` | `'primary' \| 'secondary' \| 'ghost' \| 'danger'` | no | |
+| `size` | `'sm' \| 'md' \| 'lg'` | no | |
+| `icon` | `string` | no | Icon name |
+| `disabled` | `boolean` | no | |
+| `parallel` | `boolean` | no | Run action in parallel (default: true) |
+| `submitForm` | `string` | no | Form ID to collect data from on click |
+
+**input**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `'input'` | yes | |
+| `name` | `string` | yes | Field name in form data |
+| `formId` | `string` | no | Form ID (referenced by button `submitForm`) |
+| `label` | `string` | no | |
+| `placeholder` | `string` | no | |
+| `defaultValue` | `string` | no | |
+| `variant` | `'text' \| 'email' \| 'password' \| 'number' \| 'url'` | no | |
+| `rows` | `number` | no | Renders as textarea when set |
+| `disabled` | `boolean` | no | |
+
+**select**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `'select'` | yes | |
+| `name` | `string` | yes | Field name in form data |
+| `options` | `{ value: string; label: string }[]` | yes | |
+| `formId` | `string` | no | |
+| `label` | `string` | no | |
+| `defaultValue` | `string` | no | |
+| `placeholder` | `string` | no | |
+| `disabled` | `boolean` | no | |
+
+**text**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `'text'` | yes | |
+| `content` | `string` | yes | Text content |
+| `variant` | `'body' \| 'heading' \| 'subheading' \| 'caption' \| 'code'` | no | |
+| `color` | `'default' \| 'muted' \| 'accent' \| 'success' \| 'warning' \| 'error'` | no | |
+| `textAlign` | `'left' \| 'center' \| 'right'` | no | |
+
+**badge**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `'badge'` | yes | |
+| `label` | `string` | yes | |
+| `variant` | `'default' \| 'success' \| 'warning' \| 'error' \| 'info'` | no | |
+
+**progress**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `'progress'` | yes | |
+| `value` | `number` | yes | 0–100 |
+| `label` | `string` | no | |
+| `variant` | `'default' \| 'success' \| 'warning' \| 'error'` | no | |
+| `showValue` | `boolean` | no | Show percentage text |
+
+**image**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `'image'` | yes | |
+| `src` | `string` | yes | Source URL |
+| `width` | `number \| string` | no | Width in px or CSS value |
+| `height` | `number \| string` | no | Height in px or CSS value |
+| `fit` | `'contain' \| 'cover' \| 'fill'` | no | Object fit mode |
+
+---
+
+## Union Type
+
+All actions are represented by the `OSAction` union:
+
+```typescript
+type OSAction =
+  | WindowAction
+  | NotificationAction
+  | ToastAction
+  | DialogAction
+  | AppAction
+  | DesktopAction;
+```
+
+## Type Guards
+
+| Function | Checks |
+|----------|--------|
+| `isWindowAction(action)` | `type` starts with `'window.'` |
+| `isNotificationAction(action)` | `type` starts with `'notification.'` |
+| `isToastAction(action)` | `type` starts with `'toast.'` |
+| `isDialogAction(action)` | `type` starts with `'dialog.'` |
+| `isAppAction(action)` | `type` starts with `'app.'` |
+
+## Validation Helpers
+
+| Function | Purpose |
+|----------|---------|
+| `isTableContentData(value)` | Checks `{ headers: string[], rows: string[][] }` shape |
+| `isIframeContentData(value)` | Checks for URL string or `{ url, sandbox? }` object |
+| `isComponentLayout(value)` | Checks for `{ components: [...] }` shape |
+| `isWindowContentData(renderer, value)` | Validates data matches the renderer type |
+| `isContentUpdateOperationValid(renderer, op)` | Validates an update operation is legal for the renderer |
+
+---
+
+## Processing Pipeline
+
+```
+AI emits tool call → MCP tool creates OSAction
+  → actionEmitter.emitAction(action) → BroadcastCenter
+  → WebSocket ACTIONS event → Frontend store
+  → applyAction() routes to slice handler
+```
+
+Actions are scoped by monitor. The store key format is `"monitorId/windowId"` (e.g., `"monitor-0/win-settings"`). If no `monitorId` is present in the action, it falls back to the active monitor.
+
+Multiple synchronous actions are batched into a single Immer transaction. Async actions (`window.capture`) run outside Immer.

--- a/docs/storage_api_reference.md
+++ b/docs/storage_api_reference.md
@@ -1,0 +1,352 @@
+# Storage API Reference
+
+The Storage API provides persistent file storage accessible to AI agents via MCP tools and to frontends/apps via REST endpoints. Storage is session-independent — files written in one session are available in all subsequent sessions.
+
+---
+
+## Directory Layout
+
+```
+PROJECT_ROOT/
+├── storage/                     # Persistent user files (git-ignored)
+│   ├── temp/                    # Dropped images (auto WebP conversion)
+│   ├── files/                   # Uploaded files
+│   └── {app-specific}/          # App data
+└── config/                      # Configuration (git-ignored)
+    ├── credentials/{appId}.json # App credentials
+    ├── permissions.json         # Saved permission decisions
+    ├── settings.json            # User settings
+    ├── shortcuts.json           # Desktop shortcuts
+    └── reload-cache/            # Per-session fingerprint cache
+```
+
+Default base: `PROJECT_ROOT/storage`. Override with the `YAAR_STORAGE` environment variable.
+
+---
+
+## MCP Tools
+
+Registered in the `storage` MCP namespace. Full tool names: `mcp__storage__read`, `mcp__storage__write`, `mcp__storage__list`, `mcp__storage__delete`.
+
+**Source:** `packages/server/src/mcp/storage/index.ts`
+
+### `read`
+
+Read a file from storage.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `path` | `string` | yes | Path relative to `storage/` |
+
+**Returns (text files):** File content as a UTF-8 string.
+
+**Returns (PDF files):** A summary string (`"PDF with N page(s)"` or `"PDF preview (first 3 of N pages)"`) plus base64 PNG images of up to 3 pages. The tool instructs the agent to display PDFs via an iframe window pointing at `/api/storage/<path>` rather than rendering content as markdown.
+
+**Errors:** Path traversal detected, file not found.
+
+### `write`
+
+Write a file to storage.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `path` | `string` | yes | Path relative to `storage/` |
+| `content` | `string` | yes | Content to write |
+
+Parent directories are created automatically. Overwrites existing files.
+
+**Returns:** `"Written to {path}"`
+
+### `list`
+
+List files and directories.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `path` | `string` | no | Directory path relative to `storage/` (defaults to root) |
+
+**Returns:** Formatted list with directory/file emoji prefixes. Directories are sorted first, then alphabetically by name. Returns `"Directory is empty"` for empty or nonexistent directories.
+
+Each entry includes: `path`, `isDirectory`, `size` (bytes), `modifiedAt` (ISO timestamp).
+
+### `delete`
+
+Delete a single file.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `path` | `string` | yes | Path relative to `storage/` |
+
+Does not support recursive directory deletion. Fails if the file does not exist.
+
+**Returns:** `"Deleted {path}"`
+
+---
+
+## REST API
+
+**Source:** `packages/server/src/http/routes/files.ts` (storage section)
+
+Base URL: `/api/storage/{filePath}`
+
+All paths are relative to the storage directory. Path traversal is blocked (HTTP 403).
+
+### GET — Serve file
+
+```
+GET /api/storage/documents/report.pdf
+```
+
+Returns the raw file with `Content-Type` inferred from the extension (see [MIME types](#mime-types) below). Returns `Cache-Control: no-cache`.
+
+**Status codes:** 200 (file content), 404 (not found), 403 (path traversal).
+
+### GET — List directory
+
+```
+GET /api/storage/documents/?list=true
+```
+
+Returns a JSON array of `StorageEntry` objects:
+
+```json
+[
+  { "path": "documents/readme.txt", "isDirectory": false, "size": 1024, "modifiedAt": "2025-01-01T12:00:00.000Z" },
+  { "path": "documents/images", "isDirectory": true, "size": 0, "modifiedAt": "2025-01-01T12:00:00.000Z" }
+]
+```
+
+### POST — Write file
+
+```
+POST /api/storage/notes/memo.txt
+Body: <raw file content>
+```
+
+Creates parent directories if needed. Binary-safe (supports any file type).
+
+**Maximum body size:** 50 MB. Returns HTTP 413 if exceeded.
+
+**Response:** `{ "ok": true, "path": "notes/memo.txt" }`
+
+### DELETE — Remove file
+
+```
+DELETE /api/storage/documents/old.pdf
+```
+
+**Response:** `{ "ok": true, "path": "documents/old.pdf" }`
+
+**Status codes:** 200, 404 (not found), 403 (path traversal).
+
+---
+
+## PDF Rendering Endpoint
+
+```
+GET /api/pdf/{storagePath}/{pageNumber}
+```
+
+Renders a single PDF page as a PNG image at 1.5× scale via poppler.
+
+**Example:** `GET /api/pdf/documents/paper.pdf/1` returns page 1 as `image/png`.
+
+**Status codes:** 200, 400 (not a PDF), 404 (page not found).
+
+---
+
+## Types
+
+**Source:** `packages/server/src/storage/types.ts`
+
+```typescript
+interface StorageEntry {
+  path: string;          // Relative to storage/
+  isDirectory: boolean;
+  size: number;          // Bytes (0 for directories)
+  modifiedAt: string;    // ISO 8601
+}
+
+interface StorageReadResult {
+  success: boolean;
+  content?: string;
+  images?: StorageImageContent[];
+  totalPages?: number;
+  error?: string;
+}
+
+interface StorageWriteResult {
+  success: boolean;
+  path: string;
+  error?: string;
+}
+
+interface StorageListResult {
+  success: boolean;
+  entries?: StorageEntry[];
+  error?: string;
+}
+
+interface StorageDeleteResult {
+  success: boolean;
+  path: string;
+  error?: string;
+}
+
+interface StorageImageContent {
+  type: 'image';
+  data: string;          // Base64 encoded
+  mimeType: string;
+  pageNumber?: number;
+}
+```
+
+---
+
+## Storage Manager
+
+**Source:** `packages/server/src/storage/storage-manager.ts`
+
+Core functions used by both MCP tools and REST routes:
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `storageRead` | `(filePath: string) → Promise<StorageReadResult>` | Read file; converts PDFs to images (max 3 pages) |
+| `storageWrite` | `(filePath: string, content: string \| Buffer) → Promise<StorageWriteResult>` | Write file; creates parent dirs |
+| `storageList` | `(dirPath?: string) → Promise<StorageListResult>` | List directory; returns empty list for missing dirs |
+| `storageDelete` | `(filePath: string) → Promise<StorageDeleteResult>` | Delete single file |
+| `ensureStorageDir` | `() → Promise<void>` | Create `storage/` if missing |
+| `configRead` | `(filePath: string) → Promise<StorageReadResult>` | Read from `config/` directory |
+| `configWrite` | `(filePath: string, content: string) → Promise<StorageWriteResult>` | Write to `config/` directory |
+
+### Path Validation
+
+All operations normalize the path and verify it resolves within the storage (or config) directory:
+
+```typescript
+function validatePath(filePath: string): string | null {
+  const normalizedPath = normalize(join(STORAGE_DIR, filePath));
+  const relativePath = relative(STORAGE_DIR, normalizedPath);
+  if (relativePath.startsWith('..') || relativePath.includes('..')) {
+    return null;  // path traversal blocked
+  }
+  return normalizedPath;
+}
+```
+
+Blocked patterns: `../../etc/passwd`, absolute paths, `dir/../../../secret`.
+
+---
+
+## MIME Types
+
+**Source:** `packages/server/src/config.ts`
+
+| Extension | Content-Type |
+|-----------|-------------|
+| `.png` | `image/png` |
+| `.jpg`, `.jpeg` | `image/jpeg` |
+| `.gif` | `image/gif` |
+| `.webp` | `image/webp` |
+| `.svg` | `image/svg+xml` |
+| `.ico` | `image/x-icon` |
+| `.pdf` | `application/pdf` |
+| `.json` | `application/json` |
+| `.txt` | `text/plain` |
+| `.html` | `text/html` |
+| `.css` | `text/css` |
+| `.js` | `application/javascript` |
+| `.xlsx` | `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` |
+| `.docx` | `application/vnd.openxmlformats-officedocument.wordprocessingml.document` |
+| `.csv` | `text/csv` |
+| `.zip` | `application/zip` |
+| `.md` | `text/markdown` |
+| `.xml` | `application/xml` |
+| `.mp3` | `audio/mpeg` |
+| `.mp4` | `video/mp4` |
+| `.wasm` | `application/wasm` |
+| `.ttf` | `font/ttf` |
+| `.woff` | `font/woff` |
+| `.woff2` | `font/woff2` |
+
+Unknown extensions fall back to `application/octet-stream`.
+
+---
+
+## Frontend Integration
+
+### File Upload
+
+**Source:** `packages/frontend/src/lib/uploadImage.ts`
+
+Images dropped onto the UI are converted to WebP and uploaded to `storage/temp/`:
+
+```typescript
+const res = await apiFetch(`/api/storage/${storagePath}`, {
+  method: 'POST',
+  body: file,
+});
+```
+
+Non-image files are uploaded to `storage/files/` with sanitized filenames.
+
+### Iframe SDK
+
+Apps running inside iframes can access storage via `window.yaar.storage`:
+
+| Method | Description |
+|--------|-------------|
+| `list(path)` | List directory contents |
+| `read(path, opts?)` | Read file content |
+| `save(path, content)` | Write file content |
+| `remove(path)` | Delete file |
+| `url(path)` | Get the HTTP URL: `/api/storage/{path}` |
+
+---
+
+## Configuration Storage
+
+Separate from user storage, configuration files live in `config/` (override with `YAAR_CONFIG`).
+
+### Settings
+
+**Source:** `packages/server/src/storage/settings.ts`
+
+Stored at `config/settings.json`.
+
+```typescript
+interface Settings {
+  onboardingCompleted: boolean;
+  language: string;
+}
+```
+
+| Function | Description |
+|----------|-------------|
+| `readSettings()` | Read current settings |
+| `updateSettings(partial)` | Merge partial updates |
+
+### Permissions
+
+**Source:** `packages/server/src/storage/permissions.ts`
+
+Stored at `config/permissions.json`. Records "allow" / "deny" decisions for MCP tool confirmations.
+
+| Function | Description |
+|----------|-------------|
+| `checkPermission(toolName, context?)` | Look up a saved decision |
+| `savePermission(toolName, decision, context?)` | Persist a decision |
+
+### App Credentials
+
+Stored at `config/credentials/{appId}.json`. Managed via the `apps_read_config` and `apps_write_config` MCP tools. Old credential locations (`apps/{appId}/credentials.json`, `storage/credentials/{appId}.json`) are auto-migrated on first read.
+
+---
+
+## Limits
+
+| Limit | Value |
+|-------|-------|
+| Max upload size (REST) | 50 MB |
+| Max PDF preview pages | 3 |
+| PDF render scale | 1.5× |


### PR DESCRIPTION
Three new reference documents covering the complete API surface:
- OS Actions: all action types, fields, content renderers, component DSL
- App Protocol: MCP tools, postMessage protocol, iframe SDK, manifest format
- Storage API: MCP tools, REST endpoints, types, path validation, MIME types

https://claude.ai/code/session_01UaQNyWqWqFia6YjA5V7uaE