### PR TITLE
Add user:ask and user:request MCP tools for agent-user interaction

### DIFF
--- a/packages/frontend/src/components/desktop/DesktopSurface.tsx
+++ b/packages/frontend/src/components/desktop/DesktopSurface.tsx
@@ -19,6 +19,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { ToastContainer } from '../ui/ToastContainer';
 import { NotificationCenter } from '../ui/NotificationCenter';
 import { ConfirmDialog } from '../ui/ConfirmDialog';
+import { UserPrompt } from '../ui/UserPrompt';
 import { CommandPalette } from '../ui/CommandPalette';
 import { WindowContextMenu } from '../ui/WindowContextMenu';
 import { CursorSpinner } from '../ui/CursorSpinner';
@@ -628,6 +629,7 @@ export function DesktopSurface() {
       <CommandPalette />
       <ToastContainer onToastAction={sendToastAction} />
       <ConfirmDialog />
+      <UserPrompt />
     </>
   );
 }

--- a/packages/frontend/src/components/ui/UserPrompt.tsx
+++ b/packages/frontend/src/components/ui/UserPrompt.tsx
@@ -1,0 +1,171 @@
+/**
+ * UserPrompt — renders ask/request prompts from the agent.
+ *
+ * - Options mode (ask): shows selectable options with optional freeform text.
+ * - Input mode (request): shows a text input for the user to provide a response.
+ * - Both can coexist in a single prompt.
+ */
+import { useState, useCallback } from 'react';
+import { useDesktopStore, selectUserPrompts } from '@/store';
+import { useShallow } from 'zustand/react/shallow';
+import { useAgentConnection } from '@/hooks/useAgentConnection';
+import type { UserPromptModel } from '@/types/state';
+import styles from '@/styles/ui/UserPrompt.module.css';
+
+function PromptBox({
+  prompt,
+  onSubmit,
+  onDismiss,
+}: {
+  prompt: UserPromptModel;
+  onSubmit: (promptId: string, selectedValues?: string[], text?: string) => void;
+  onDismiss: (promptId: string) => void;
+}) {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [text, setText] = useState('');
+
+  const hasOptions = prompt.options && prompt.options.length > 0;
+  const hasInput = !!prompt.inputField;
+
+  const toggleOption = useCallback(
+    (value: string) => {
+      setSelected((prev) => {
+        const next = new Set(prev);
+        if (prompt.multiSelect) {
+          if (next.has(value)) next.delete(value);
+          else next.add(value);
+        } else {
+          if (next.has(value)) next.clear();
+          else {
+            next.clear();
+            next.add(value);
+          }
+        }
+        return next;
+      });
+    },
+    [prompt.multiSelect],
+  );
+
+  const canSubmit = hasOptions
+    ? selected.size > 0 || text.trim().length > 0
+    : text.trim().length > 0;
+
+  const handleSubmit = () => {
+    const selectedValues = selected.size > 0 ? Array.from(selected) : undefined;
+    const inputText = text.trim() || undefined;
+    onSubmit(prompt.id, selectedValues, inputText);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey && canSubmit) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  return (
+    <div className={styles.prompt}>
+      <div className={styles.title}>{prompt.title}</div>
+      <div className={styles.message}>{prompt.message}</div>
+
+      {hasOptions && (
+        <div className={styles.options}>
+          {prompt.options!.map((opt) => (
+            <div
+              key={opt.value}
+              className={styles.option}
+              data-selected={selected.has(opt.value)}
+              onClick={() => toggleOption(opt.value)}
+            >
+              <input
+                type={prompt.multiSelect ? 'checkbox' : 'radio'}
+                className={styles.optionRadio}
+                checked={selected.has(opt.value)}
+                onChange={() => toggleOption(opt.value)}
+                name={`prompt-${prompt.id}`}
+              />
+              <div className={styles.optionContent}>
+                <span className={styles.optionLabel}>{opt.label}</span>
+                {opt.description && (
+                  <span className={styles.optionDescription}>{opt.description}</span>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {hasInput && (
+        <div className={styles.inputGroup}>
+          {prompt.inputField!.label && (
+            <label className={styles.inputLabel}>{prompt.inputField!.label}</label>
+          )}
+          {prompt.inputField!.type === 'textarea' ? (
+            <textarea
+              className={styles.textArea}
+              placeholder={prompt.inputField!.placeholder}
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              onKeyDown={handleKeyDown}
+              rows={4}
+              autoFocus
+            />
+          ) : (
+            <input
+              type={prompt.inputField!.type === 'password' ? 'password' : 'text'}
+              className={styles.textInput}
+              placeholder={prompt.inputField!.placeholder}
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              onKeyDown={handleKeyDown}
+              autoFocus
+            />
+          )}
+        </div>
+      )}
+
+      <div className={styles.buttons}>
+        {prompt.allowDismiss !== false && (
+          <button className={styles.dismissButton} onClick={() => onDismiss(prompt.id)}>
+            Skip
+          </button>
+        )}
+        <button className={styles.submitButton} disabled={!canSubmit} onClick={handleSubmit}>
+          Submit
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function UserPrompt() {
+  const prompts = useDesktopStore(useShallow(selectUserPrompts)) as UserPromptModel[];
+  const dismissUserPrompt = useDesktopStore((s) => s.dismissUserPrompt);
+  const { sendUserPromptResponse } = useAgentConnection();
+
+  const handleSubmit = (promptId: string, selectedValues?: string[], text?: string) => {
+    sendUserPromptResponse(promptId, selectedValues, text);
+    dismissUserPrompt(promptId);
+  };
+
+  const handleDismiss = (promptId: string) => {
+    sendUserPromptResponse(promptId, undefined, undefined, true);
+    dismissUserPrompt(promptId);
+  };
+
+  if (prompts.length === 0) return null;
+
+  return (
+    <div className={styles.overlay}>
+      {prompts.map((prompt) => (
+        <PromptBox
+          key={prompt.id}
+          prompt={prompt}
+          onSubmit={handleSubmit}
+          onDismiss={handleDismiss}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/frontend/src/hooks/useAgentConnection.ts
+++ b/packages/frontend/src/hooks/useAgentConnection.ts
@@ -266,6 +266,13 @@ export function useAgentConnection(options: UseAgentConnectionOptions = {}) {
     [send],
   );
 
+  const sendUserPromptResponse = useCallback(
+    (promptId: string, selectedValues?: string[], text?: string, dismissed?: boolean) => {
+      send({ type: 'USER_PROMPT_RESPONSE', promptId, selectedValues, text, dismissed });
+    },
+    [send],
+  );
+
   const sendComponentAction = useCallback(
     (
       windowId: string,
@@ -492,6 +499,7 @@ export function useAgentConnection(options: UseAgentConnectionOptions = {}) {
     sendComponentAction,
     sendDialogFeedback,
     sendToastAction,
+    sendUserPromptResponse,
     interrupt,
     interruptAgent,
     setProvider,

--- a/packages/frontend/src/store/desktop.ts
+++ b/packages/frontend/src/store/desktop.ts
@@ -41,6 +41,7 @@ import {
   createImageAttachSlice,
   createCliSlice,
   createMonitorSlice,
+  createUserPromptsSlice,
 } from './slices';
 
 // Import pure mutation functions for batched action processing
@@ -48,6 +49,7 @@ import { applyWindowAction } from './slices/windowsSlice';
 import { applyNotificationAction } from './slices/notificationsSlice';
 import { applyToastAction } from './slices/toastsSlice';
 import { applyDialogAction } from './slices/dialogsSlice';
+import { applyUserPromptAction } from './slices/userPromptsSlice';
 
 /**
  * Try capturing iframe content via the postMessage self-capture protocol.
@@ -396,6 +398,7 @@ export const useDesktopStore = create<DesktopStore>()(
     ...createNotificationsSlice(...a),
     ...createToastsSlice(...a),
     ...createDialogsSlice(...a),
+    ...createUserPromptsSlice(...a),
     ...createConnectionSlice(...a),
     ...createDebugSlice(...a),
     ...createAgentsSlice(...a),
@@ -452,6 +455,8 @@ export const useDesktopStore = create<DesktopStore>()(
         store.handleToastAction(action);
       } else if (actionType.startsWith('dialog.')) {
         store.handleDialogAction(action);
+      } else if (actionType.startsWith('user.prompt.')) {
+        store.handleUserPromptAction(action);
       } else if (actionType === 'app.badge') {
         const { appId, count } = action as import('@yaar/shared').AppBadgeAction;
         const [set] = a;
@@ -506,6 +511,7 @@ export const useDesktopStore = create<DesktopStore>()(
             else if (t.startsWith('notification.')) applyNotificationAction(state, action);
             else if (t.startsWith('toast.')) applyToastAction(state, action);
             else if (t.startsWith('dialog.')) applyDialogAction(state, action);
+            else if (t.startsWith('user.prompt.')) applyUserPromptAction(state, action);
             else if (t === 'app.badge') {
               const { appId, count } = action as import('@yaar/shared').AppBadgeAction;
               if (count > 0) state.appBadges[appId] = count;
@@ -540,6 +546,7 @@ export const useDesktopStore = create<DesktopStore>()(
         state.notifications = {};
         state.toasts = {};
         state.dialogs = {};
+        state.userPrompts = {};
         state.activeAgents = {};
         state.windowAgents = {};
         state.queuedActions = {};
@@ -573,6 +580,7 @@ export {
   selectToasts,
   selectNotifications,
   selectDialogs,
+  selectUserPrompts,
   selectActiveAgents,
   selectWindowAgents,
   selectWindowAgent,

--- a/packages/frontend/src/store/index.ts
+++ b/packages/frontend/src/store/index.ts
@@ -11,6 +11,7 @@ export {
   selectToasts,
   selectNotifications,
   selectDialogs,
+  selectUserPrompts,
   selectActiveAgents,
   selectWindowAgents,
   selectWindowAgent,

--- a/packages/frontend/src/store/selectors.ts
+++ b/packages/frontend/src/store/selectors.ts
@@ -83,6 +83,8 @@ export const selectNotifications = (state: DesktopStore) => Object.values(state.
 
 export const selectDialogs = (state: DesktopStore) => Object.values(state.dialogs);
 
+export const selectUserPrompts = (state: DesktopStore) => Object.values(state.userPrompts);
+
 export const selectActiveAgents = (state: DesktopStore) => Object.values(state.activeAgents);
 
 export const selectWindowAgents = (state: DesktopStore) => state.windowAgents;

--- a/packages/frontend/src/store/slices/index.ts
+++ b/packages/frontend/src/store/slices/index.ts
@@ -4,6 +4,7 @@
 export { createToastsSlice } from './toastsSlice';
 export { createNotificationsSlice } from './notificationsSlice';
 export { createDialogsSlice } from './dialogsSlice';
+export { createUserPromptsSlice } from './userPromptsSlice';
 export { createConnectionSlice } from './connectionSlice';
 export { createDebugSlice } from './debugSlice';
 export { createAgentsSlice } from './agentsSlice';

--- a/packages/frontend/src/store/slices/userPromptsSlice.ts
+++ b/packages/frontend/src/store/slices/userPromptsSlice.ts
@@ -1,0 +1,46 @@
+/**
+ * User prompts slice — manages ask/request prompts from the agent.
+ */
+import type { SliceCreator, UserPromptsSlice, UserPromptsSliceState } from '../types';
+import type { OSAction, UserPromptShowAction } from '@yaar/shared';
+
+/**
+ * Pure mutation function that applies a user prompt action to an Immer draft.
+ */
+export function applyUserPromptAction(state: UserPromptsSliceState, action: OSAction): void {
+  switch (action.type) {
+    case 'user.prompt.show': {
+      const a = action as UserPromptShowAction;
+      state.userPrompts[a.id] = {
+        id: a.id,
+        title: a.title,
+        message: a.message,
+        options: a.options,
+        multiSelect: a.multiSelect,
+        inputField: a.inputField,
+        allowDismiss: a.allowDismiss,
+        timestamp: Date.now(),
+      };
+      break;
+    }
+    case 'user.prompt.dismiss': {
+      const id = (action as { id: string }).id;
+      delete state.userPrompts[id];
+      break;
+    }
+  }
+}
+
+export const createUserPromptsSlice: SliceCreator<UserPromptsSlice> = (set, _get) => ({
+  userPrompts: {},
+
+  handleUserPromptAction: (action: OSAction) =>
+    set((state) => {
+      applyUserPromptAction(state, action);
+    }),
+
+  dismissUserPrompt: (id) =>
+    set((state) => {
+      delete state.userPrompts[id];
+    }),
+});

--- a/packages/frontend/src/store/types.ts
+++ b/packages/frontend/src/store/types.ts
@@ -10,6 +10,7 @@ import type {
   NotificationModel,
   ToastModel,
   DialogModel,
+  UserPromptModel,
   ConnectionStatus,
   ContextMenuState,
   RestorePrompt,
@@ -29,6 +30,7 @@ export type {
   NotificationModel,
   ToastModel,
   DialogModel,
+  UserPromptModel,
   ConnectionStatus,
   ContextMenuState,
   RestorePrompt,
@@ -92,6 +94,17 @@ export interface DialogsSliceActions {
 }
 
 export type DialogsSlice = DialogsSliceState & DialogsSliceActions;
+
+export interface UserPromptsSliceState {
+  userPrompts: Record<string, UserPromptModel>;
+}
+
+export interface UserPromptsSliceActions {
+  handleUserPromptAction: (action: OSAction) => void;
+  dismissUserPrompt: (id: string) => void;
+}
+
+export type UserPromptsSlice = UserPromptsSliceState & UserPromptsSliceActions;
 
 export interface ConnectionSliceState {
   connectionStatus: ConnectionStatus;
@@ -313,6 +326,7 @@ export type DesktopStore = WindowsSlice &
   NotificationsSlice &
   ToastsSlice &
   DialogsSlice &
+  UserPromptsSlice &
   ConnectionSlice &
   DebugSlice &
   AgentsSlice &

--- a/packages/frontend/src/styles/ui/UserPrompt.module.css
+++ b/packages/frontend/src/styles/ui/UserPrompt.module.css
@@ -1,0 +1,180 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--bg-modal-backdrop);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: var(--z-modal);
+}
+
+.prompt {
+  background: var(--color-base);
+  border: var(--border-subtle);
+  border-radius: var(--radius-xl);
+  padding: var(--space-6);
+  min-width: 400px;
+  max-width: 520px;
+  box-shadow: var(--shadow-2xl);
+}
+
+.title {
+  font-size: var(--text-2xl);
+  font-weight: 600;
+  color: var(--color-text);
+  margin-bottom: var(--space-3);
+}
+
+.message {
+  font-size: var(--text-lg);
+  color: var(--color-subtext);
+  margin-bottom: var(--space-5);
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+/* Options list (ask) */
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-bottom: var(--space-5);
+}
+
+.option {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-lg);
+  border: var(--border-subtle);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  user-select: none;
+}
+
+.option:hover {
+  background: var(--bg-overlay-light);
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.option[data-selected='true'] {
+  background: rgba(137, 180, 250, 0.1);
+  border-color: var(--color-blue);
+}
+
+.optionRadio {
+  width: var(--space-4);
+  height: var(--space-4);
+  margin-top: 2px;
+  accent-color: var(--color-blue);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.optionContent {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.optionLabel {
+  font-size: var(--text-lg);
+  color: var(--color-text);
+  font-weight: 500;
+}
+
+.optionDescription {
+  font-size: var(--text-sm);
+  color: var(--color-subtext-muted);
+  line-height: 1.4;
+}
+
+/* Text input (request) */
+.inputGroup {
+  margin-bottom: var(--space-5);
+}
+
+.inputLabel {
+  display: block;
+  font-size: var(--text-md);
+  color: var(--color-subtext);
+  margin-bottom: var(--space-2);
+  font-weight: 500;
+}
+
+.textInput,
+.textArea {
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--text-lg);
+  color: var(--color-text);
+  background: var(--bg-overlay-light);
+  border: var(--border-subtle);
+  border-radius: var(--radius-lg);
+  outline: none;
+  font-family: inherit;
+  transition: border-color var(--transition-fast);
+  box-sizing: border-box;
+}
+
+.textInput:focus,
+.textArea:focus {
+  border-color: var(--color-blue);
+}
+
+.textArea {
+  resize: vertical;
+  min-height: 80px;
+}
+
+/* Buttons */
+.buttons {
+  display: flex;
+  gap: var(--space-3);
+  justify-content: flex-end;
+}
+
+.dismissButton,
+.submitButton {
+  padding: 10px var(--space-5);
+  border-radius: var(--radius-lg);
+  font-size: var(--text-lg);
+  font-weight: 500;
+  cursor: pointer;
+  border: none;
+  transition: all var(--transition-fast);
+}
+
+.dismissButton {
+  background: var(--bg-overlay-medium);
+  color: var(--color-text);
+  border: var(--border-subtle);
+}
+
+.dismissButton:hover {
+  background: var(--bg-overlay-strong);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.submitButton {
+  background: var(--color-blue);
+  color: var(--color-base);
+}
+
+.submitButton:hover {
+  background: var(--color-lavender);
+}
+
+.submitButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.dismissButton:active,
+.submitButton:active {
+  transform: scale(0.98);
+}

--- a/packages/frontend/src/types/state.ts
+++ b/packages/frontend/src/types/state.ts
@@ -66,6 +66,17 @@ export interface DialogModel {
   permissionOptions?: PermissionOptions;
 }
 
+export interface UserPromptModel {
+  id: string;
+  title: string;
+  message: string;
+  options?: { value: string; label: string; description?: string }[];
+  multiSelect?: boolean;
+  inputField?: { label?: string; placeholder?: string; type?: 'text' | 'textarea' | 'password' };
+  allowDismiss?: boolean;
+  timestamp: number;
+}
+
 export type ConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'error';
 
 export interface ContextMenuState {

--- a/packages/server/src/mcp/index.ts
+++ b/packages/server/src/mcp/index.ts
@@ -23,6 +23,7 @@ export { registerMarketTools, MARKET_TOOL_NAMES } from './apps/market.js';
 export { registerHttpTools, HTTP_TOOL_NAMES } from './http/index.js';
 export { registerAppDevTools, DEV_TOOL_NAMES } from './dev/index.js';
 export { registerSandboxTools, SANDBOX_TOOL_NAMES } from './sandbox/index.js';
+export { registerUserTools, USER_TOOL_NAMES } from './user/index.js';
 
 // Action emitter
 export { actionEmitter, type ActionEvent, type RenderingFeedback } from './action-emitter.js';

--- a/packages/server/src/mcp/register.ts
+++ b/packages/server/src/mcp/register.ts
@@ -22,6 +22,7 @@ import { getSessionHub } from '../session/live-session.js';
 import type { WindowStateRegistry } from './window-state.js';
 import type { ReloadCache } from '../reload/cache.js';
 import { APP_DEV_ENABLED } from '../config.js';
+import { registerUserTools, USER_TOOL_NAMES } from './user/index.js';
 import { registerBrowserTools, BROWSER_TOOL_NAMES } from './browser/index.js';
 
 /**
@@ -49,6 +50,7 @@ export function registerAllTools(servers: Record<McpServerName, McpServer>): voi
   registerStorageTools(servers.storage);
   registerAppsTools(servers.apps);
   registerMarketTools(servers.apps);
+  registerUserTools(servers.user);
   if (APP_DEV_ENABLED) {
     registerAppDevTools(servers.dev);
   }
@@ -86,6 +88,7 @@ export function getToolNames(): string[] {
     ...STORAGE_TOOL_NAMES,
     ...APPS_TOOL_NAMES,
     ...MARKET_TOOL_NAMES,
+    ...USER_TOOL_NAMES,
     ...DEV_TOOL_NAMES,
     ...RELOAD_TOOL_NAMES,
     ...BROWSER_TOOL_NAMES,

--- a/packages/server/src/mcp/server.ts
+++ b/packages/server/src/mcp/server.ts
@@ -13,7 +13,15 @@ import { registerAllTools } from './register.js';
 import { runWithAgentId } from '../agents/session.js';
 
 /** MCP server categories. */
-export const MCP_SERVERS = ['system', 'window', 'storage', 'apps', 'dev', 'browser'] as const;
+export const MCP_SERVERS = [
+  'system',
+  'window',
+  'storage',
+  'apps',
+  'user',
+  'dev',
+  'browser',
+] as const;
 export type McpServerName = (typeof MCP_SERVERS)[number];
 
 interface McpServerEntry {

--- a/packages/server/src/mcp/user/index.ts
+++ b/packages/server/src/mcp/user/index.ts
@@ -1,0 +1,122 @@
+/**
+ * User interaction tools — ask and request.
+ *
+ * Lightweight prompts that let the agent clarify information (ask)
+ * or delegate tasks to the user (request) without building full
+ * component windows.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { actionEmitter } from '../action-emitter.js';
+import { ok, error } from '../utils.js';
+
+export const USER_TOOL_NAMES = ['ask', 'request'] as const;
+
+export function registerUserTools(server: McpServer): void {
+  // ask — structured clarification with options
+  server.registerTool(
+    'ask',
+    {
+      description:
+        'Ask the user a question and wait for their answer. ' +
+        'Shows a compact dialog with selectable options. ' +
+        'Use for clarification before proceeding (e.g. "Which database?" or "Include tests?").',
+      inputSchema: {
+        title: z.string().describe('Short title for the prompt (e.g. "Database Choice")'),
+        message: z.string().describe('The question to ask'),
+        options: z
+          .array(
+            z.object({
+              value: z.string().describe('Machine-readable value returned on selection'),
+              label: z.string().describe('Human-readable label shown to user'),
+              description: z.string().optional().describe('Optional explanation for this option'),
+            }),
+          )
+          .min(2)
+          .describe('Available options (minimum 2)'),
+        multiSelect: z
+          .boolean()
+          .optional()
+          .describe('Allow selecting multiple options (default: false)'),
+        allowText: z
+          .boolean()
+          .optional()
+          .describe('Include a freeform text field for "Other" responses (default: false)'),
+      },
+    },
+    async (args) => {
+      const result = await actionEmitter.showUserPrompt({
+        title: args.title,
+        message: args.message,
+        options: args.options,
+        multiSelect: args.multiSelect,
+        inputField: args.allowText ? { placeholder: 'Type your answer…' } : undefined,
+        allowDismiss: true,
+      });
+
+      if (result.dismissed) {
+        return error('User dismissed the prompt without answering.');
+      }
+
+      const parts: string[] = [];
+      if (result.selectedValues?.length) {
+        parts.push(`Selected: ${result.selectedValues.join(', ')}`);
+      }
+      if (result.text) {
+        parts.push(`Text: ${result.text}`);
+      }
+      return ok(parts.join('\n') || 'No selection made.');
+    },
+  );
+
+  // request — delegate a task to the user with text response
+  server.registerTool(
+    'request',
+    {
+      description:
+        'Request the user to perform an action and provide a text response. ' +
+        'Shows a prompt with a text input field. ' +
+        'Use when you need the user to do something you cannot ' +
+        '(e.g. "Paste your API key", "Run this command and share the output", ' +
+        '"Check the deployment URL and confirm it works").',
+      inputSchema: {
+        title: z.string().describe('Short title (e.g. "API Key Needed")'),
+        message: z
+          .string()
+          .describe('What you need the user to do and why (be specific and helpful)'),
+        inputLabel: z
+          .string()
+          .optional()
+          .describe('Label for the text input (e.g. "API Key", "Command Output")'),
+        inputPlaceholder: z.string().optional().describe('Placeholder text for the input field'),
+        multiline: z
+          .boolean()
+          .optional()
+          .describe('Use a multiline textarea instead of single-line input (default: false)'),
+      },
+    },
+    async (args) => {
+      const result = await actionEmitter.showUserPrompt({
+        title: args.title,
+        message: args.message,
+        inputField: {
+          label: args.inputLabel,
+          placeholder: args.inputPlaceholder,
+          type: args.multiline ? 'textarea' : 'text',
+        },
+        allowDismiss: true,
+      });
+
+      if (result.dismissed) {
+        return error('User dismissed the request without responding.');
+      }
+
+      if (!result.text) {
+        return error('User submitted an empty response.');
+      }
+
+      return ok(result.text);
+    },
+  );
+}

--- a/packages/server/src/session/live-session.ts
+++ b/packages/server/src/session/live-session.ts
@@ -394,6 +394,15 @@ export class LiveSession {
         );
         break;
 
+      case 'USER_PROMPT_RESPONSE':
+        actionEmitter.resolveUserPromptFeedback({
+          promptId: event.promptId,
+          selectedValues: event.selectedValues,
+          text: event.text,
+          dismissed: event.dismissed,
+        });
+        break;
+
       case 'USER_INTERACTION': {
         const logger = this.pool?.getSessionLogger();
 

--- a/packages/shared/src/actions.ts
+++ b/packages/shared/src/actions.ts
@@ -192,6 +192,43 @@ export interface DialogConfirmAction {
   permissionOptions?: PermissionOptions;
 }
 
+// ============ User Prompt Actions ============
+
+export interface UserPromptOption {
+  value: string;
+  label: string;
+  description?: string;
+}
+
+export interface UserPromptInputField {
+  label?: string;
+  placeholder?: string;
+  type?: 'text' | 'textarea' | 'password';
+}
+
+/**
+ * Flexible user prompt that covers both "ask" (options) and "request" (text input) use cases.
+ *
+ * - Options only → radio/checkbox selection (ask)
+ * - InputField only → text input (request)
+ * - Both → options with an "Other" freeform field
+ */
+export interface UserPromptShowAction {
+  type: 'user.prompt.show';
+  id: string;
+  title: string;
+  message: string;
+  options?: UserPromptOption[];
+  multiSelect?: boolean;
+  inputField?: UserPromptInputField;
+  allowDismiss?: boolean;
+}
+
+export interface UserPromptDismissAction {
+  type: 'user.prompt.dismiss';
+  id: string;
+}
+
 // ============ App Actions ============
 
 export interface AppBadgeAction {
@@ -256,6 +293,8 @@ export type ToastAction = ToastShowAction | ToastDismissAction;
 
 export type DialogAction = DialogConfirmAction;
 
+export type UserPromptAction = UserPromptShowAction | UserPromptDismissAction;
+
 export type AppAction = AppBadgeAction;
 
 export type DesktopAction =
@@ -269,6 +308,7 @@ export type OSAction =
   | NotificationAction
   | ToastAction
   | DialogAction
+  | UserPromptAction
   | AppAction
   | DesktopAction;
 
@@ -288,6 +328,10 @@ export function isToastAction(action: OSAction): action is ToastAction {
 
 export function isDialogAction(action: OSAction): action is DialogAction {
   return action.type.startsWith('dialog.');
+}
+
+export function isUserPromptAction(action: OSAction): action is UserPromptAction {
+  return action.type.startsWith('user.prompt.');
 }
 
 export function isAppAction(action: OSAction): action is AppAction {

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -122,6 +122,14 @@ export interface ToastActionEvent {
   eventId: string;
 }
 
+export interface UserPromptResponseEvent {
+  type: 'USER_PROMPT_RESPONSE';
+  promptId: string;
+  selectedValues?: string[];
+  text?: string;
+  dismissed?: boolean;
+}
+
 export interface UserInteractionEvent {
   type: 'USER_INTERACTION';
   interactions: UserInteraction[];
@@ -160,6 +168,7 @@ export type ClientEvent =
   | ComponentActionEvent
   | DialogFeedbackEvent
   | ToastActionEvent
+  | UserPromptResponseEvent
   | UserInteractionEvent
   | AppProtocolResponseEvent
   | AppProtocolReadyEvent


### PR DESCRIPTION
New 'user' MCP tool group with two tools that let the agent prompt users
for structured input without building full component windows:

- user:ask — show a dialog with selectable options for clarification
  (e.g. "Which database?" with PostgreSQL/MySQL/SQLite choices)
- user:request — show a text input prompt for task delegation
  (e.g. "Paste your API key" or "Run this command and share output")

Both tools block until the user responds and return structured results.
Implemented across all three packages:

Shared: UserPromptAction types, USER_PROMPT_RESPONSE event
Server: ActionEmitter.showUserPrompt(), user MCP server namespace,
        tool handlers, live-session event routing
Frontend: userPromptsSlice, UserPrompt component with options/text
          input UI, WebSocket response wiring

https://claude.ai/code/session_01BANAryHSTa7F4ZoJkB6Txu