### PR TITLE
feat: launch exe in standalone app window instead of browser tab

### DIFF
--- a/packages/frontend/src/components/desktop/DesktopSurface.tsx
+++ b/packages/frontend/src/components/desktop/DesktopSurface.tsx
@@ -83,7 +83,7 @@ export function DesktopSurface() {
 
   const [selectedAppIds, setSelectedAppIds] = useState<Set<string>>(new Set());
 
-  // Global keyboard shortcuts: Shift+Tab for CLI mode, Ctrl+1..9 for monitors
+  // Global keyboard shortcuts: Shift+Tab for CLI mode, Ctrl+1..9 for monitors, Ctrl+W to close focused window
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Tab' && e.shiftKey) {
@@ -97,6 +97,14 @@ export function DesktopSurface() {
         if (idx < mons.length) {
           e.preventDefault();
           switchMonitor(mons[idx].id);
+        }
+      }
+      // Ctrl+W: close the focused OS window (prevents browser tab close in --app mode)
+      if (e.ctrlKey && e.key === 'w') {
+        const { focusedWindowId: fwId, userCloseWindow } = useDesktopStore.getState();
+        if (fwId) {
+          e.preventDefault();
+          userCloseWindow(fwId);
         }
       }
     };

--- a/packages/server/src/exe-entry.ts
+++ b/packages/server/src/exe-entry.ts
@@ -3,11 +3,13 @@
  * YAAR Standalone Executable Entry Point
  *
  * This file is the entry point for the bundled .exe.
- * It imports and starts the server, then auto-opens the browser.
+ * It imports and starts the server, then auto-opens in app mode
+ * (Chrome/Edge --app flag for a standalone window without browser chrome).
  */
 
-import { spawn } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 import { platform } from 'os';
+import { existsSync } from 'fs';
 
 // Import and start the server
 // The server starts automatically on import
@@ -17,27 +19,82 @@ import './index.js';
 const PORT = process.env.PORT || '8000';
 const URL = `http://127.0.0.1:${PORT}`;
 
-// Wait for server to start, then open browser
-setTimeout(() => {
-  console.log(`Opening browser: ${URL}`);
-
+/**
+ * Find a Chromium-based browser that supports --app mode.
+ * Returns the executable path or null if not found.
+ */
+function findChromiumBrowser(): string | null {
   const currentPlatform = platform();
 
+  if (currentPlatform === 'win32') {
+    // Common install locations for Chrome and Edge on Windows
+    const candidates = [
+      `${process.env.PROGRAMFILES}\\Google\\Chrome\\Application\\chrome.exe`,
+      `${process.env['PROGRAMFILES(X86)']}\\Google\\Chrome\\Application\\chrome.exe`,
+      `${process.env.LOCALAPPDATA}\\Google\\Chrome\\Application\\chrome.exe`,
+      `${process.env.PROGRAMFILES}\\Microsoft\\Edge\\Application\\msedge.exe`,
+      `${process.env['PROGRAMFILES(X86)']}\\Microsoft\\Edge\\Application\\msedge.exe`,
+    ];
+    for (const path of candidates) {
+      if (path && existsSync(path)) return path;
+    }
+  } else if (currentPlatform === 'darwin') {
+    const candidates = [
+      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+      '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    ];
+    for (const path of candidates) {
+      if (existsSync(path)) return path;
+    }
+  } else {
+    // Linux: check via `which`
+    for (const cmd of [
+      'google-chrome',
+      'google-chrome-stable',
+      'chromium',
+      'chromium-browser',
+      'microsoft-edge',
+    ]) {
+      const result = spawnSync('which', [cmd], { stdio: 'pipe' });
+      if (result.status === 0) {
+        return result.stdout.toString().trim();
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Launch the app in a standalone window (--app mode) or fall back to default browser.
+ */
+function openAppWindow() {
+  const currentPlatform = platform();
+  const chromium = findChromiumBrowser();
+
+  if (chromium) {
+    console.log(`Opening app window: ${chromium} --app=${URL}`);
+    spawn(chromium, [`--app=${URL}`], {
+      detached: true,
+      stdio: 'ignore',
+    }).unref();
+    return;
+  }
+
+  // Fallback: open in default browser
+  console.log(`No Chromium browser found. Opening default browser: ${URL}`);
   try {
     if (currentPlatform === 'win32') {
-      // Windows: use 'start' command
       spawn('cmd', ['/c', 'start', '', URL], {
         detached: true,
         stdio: 'ignore',
       }).unref();
     } else if (currentPlatform === 'darwin') {
-      // macOS: use 'open' command
       spawn('open', [URL], {
         detached: true,
         stdio: 'ignore',
       }).unref();
     } else {
-      // Linux: use 'xdg-open' command
       spawn('xdg-open', [URL], {
         detached: true,
         stdio: 'ignore',
@@ -46,7 +103,10 @@ setTimeout(() => {
   } catch {
     console.log(`Could not auto-open browser. Please visit: ${URL}`);
   }
-}, 1500);
+}
+
+// Wait for server to start, then open app window
+setTimeout(openAppWindow, 1500);
 
 // Keep the process running
 process.on('SIGINT', () => {


### PR DESCRIPTION
- Detect Chrome/Edge and launch with --app flag for a frameless,
  standalone window (no address bar, no tabs)
- Falls back to default browser if no Chromium browser is found
- Add Ctrl+W global shortcut to close the focused YAAR OS window
  (prevents closing the entire app window in --app mode)

https://claude.ai/code/session_01Qc5E4SrueuA5ceoZeEcHKJ