### PR TITLE
Fix Windows compiler bundle failure by normalizing paths to forward s…

### DIFF
--- a/packages/compiler/src/compile.ts
+++ b/packages/compiler/src/compile.ts
@@ -7,7 +7,12 @@
 
 import { mkdir, stat } from 'fs/promises';
 import { join } from 'path';
-import { bundledLibraryPluginBun, cssFilePlugin, solidHtmlClosingTagPlugin } from './plugins.js';
+import {
+  bundledLibraryPluginBun,
+  cssFilePlugin,
+  solidHtmlClosingTagPlugin,
+  toForwardSlash,
+} from './plugins.js';
 import { extractProtocolFromSource } from './extract-protocol.js';
 import { getCompilerConfig } from './config.js';
 import {
@@ -126,7 +131,7 @@ function escapeHtml(text: string): string {
  */
 async function compileWithBun(entryPoint: string, minify: boolean): Promise<string> {
   const result = await Bun.build({
-    entrypoints: [entryPoint],
+    entrypoints: [toForwardSlash(entryPoint)],
     minify,
     format: 'esm',
     target: 'browser',

--- a/packages/compiler/src/plugins.ts
+++ b/packages/compiler/src/plugins.ts
@@ -10,8 +10,15 @@ import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
+/**
+ * Normalize a file path to use forward slashes.
+ * On Windows, path.join/resolve produce backslashes which can cause
+ * Bun.build() plugin resolution failures ("AggregateError: Bundle failed").
+ */
+export const toForwardSlash = (p: string): string => p.replace(/\\/g, '/');
+
 /** Directory of this file — inside packages/compiler, where devDependencies are installed. */
-const PLUGIN_DIR = dirname(fileURLToPath(import.meta.url));
+const PLUGIN_DIR = toForwardSlash(dirname(fileURLToPath(import.meta.url)));
 
 /**
  * Local shim files that wrap npm libraries with compatibility fixes.
@@ -19,8 +26,8 @@ const PLUGIN_DIR = dirname(fileURLToPath(import.meta.url));
  * instead of the npm package directly.
  */
 const BUNDLED_SHIMS: Record<string, string> = {
-  anime: join(PLUGIN_DIR, 'shims', 'anime.ts'),
-  yaar: join(PLUGIN_DIR, 'shims', 'yaar.ts'),
+  anime: toForwardSlash(join(PLUGIN_DIR, 'shims', 'anime.ts')),
+  yaar: toForwardSlash(join(PLUGIN_DIR, 'shims', 'yaar.ts')),
 };
 
 /**
@@ -89,7 +96,7 @@ function resolveBrowserEntry(npmName: string, fromDir: string): string | null {
     const browser = exportEntry.browser;
     if (browser) {
       const entry = typeof browser === 'string' ? browser : (browser.import ?? browser.default);
-      if (entry) return join(pkgDir, entry);
+      if (entry) return toForwardSlash(join(pkgDir, entry));
     }
 
     return null;
@@ -181,8 +188,8 @@ export function bundledLibraryPluginBun(): Bun.BunPlugin {
         }
 
         // Strategy 2: disk libs (dev exe) — bundled-libs/ next to executable
-        const exeDir = dirname(process.execPath);
-        const diskPath = join(exeDir, 'bundled-libs', `${libName}.js`);
+        const exeDir = toForwardSlash(dirname(process.execPath));
+        const diskPath = toForwardSlash(join(exeDir, 'bundled-libs', `${libName}.js`));
         const diskFile = Bun.file(diskPath);
         if (await diskFile.exists()) {
           const contents = await diskFile.text();

--- a/packages/compiler/src/typecheck.ts
+++ b/packages/compiler/src/typecheck.ts
@@ -7,6 +7,7 @@
 import { unlink } from 'fs/promises';
 import { join, resolve } from 'path';
 import { getCompilerConfig } from './config.js';
+import { toForwardSlash } from './plugins.js';
 
 export interface TypecheckResult {
   success: boolean;
@@ -14,12 +15,14 @@ export interface TypecheckResult {
 }
 
 function getBundledTypesDir(): string {
-  return resolve(getCompilerConfig().projectRoot, 'packages/compiler/src/bundled-types');
+  return toForwardSlash(
+    resolve(getCompilerConfig().projectRoot, 'packages/compiler/src/bundled-types'),
+  );
 }
 
 function getTscPath(): string {
   // tsc is a devDependency of @yaar/compiler, so resolve from this package
-  return resolve(import.meta.dir, '../node_modules/.bin/tsc');
+  return toForwardSlash(resolve(import.meta.dir, '../node_modules/.bin/tsc'));
 }
 
 /**


### PR DESCRIPTION
…lashes

On Windows, path.join/resolve produce backslash paths (C:\foo\bar) which cause Bun.build() plugin resolution failures ("AggregateError: Bundle failed"). Added toForwardSlash() utility and applied it to all paths flowing into Bun APIs: plugin onResolve return values, Bun.build() entrypoints, disk-based library resolution, and tsconfig.json paths for typecheck.

Fixes #20

https://claude.ai/code/session_015qMd7bK5P2FfGDm3aq52fT