### PR TITLE
Add response hook for monitor-to-app-agent message flow

### DIFF
--- a/packages/server/src/agents/app-task-processor.ts
+++ b/packages/server/src/agents/app-task-processor.ts
@@ -157,6 +157,11 @@ export class AppTaskProcessor {
               monitorSrc,
             );
           }
+
+          // Fire message hook if the originating agent requested it
+          if (task.hook === 'response' && task.monitorId) {
+            this.ctx.notifyHookResponse(appId, windowId, task.monitorId, appResponseText);
+          }
         },
         onFinally: async () => {
           await this.sendWindowStatus(windowId, agentRole, 'released');

--- a/packages/server/src/agents/context-pool.ts
+++ b/packages/server/src/agents/context-pool.ts
@@ -128,6 +128,23 @@ export class ContextPool implements PoolContext {
     this.broadcastFn(event);
   }
 
+  notifyHookResponse(
+    appId: string,
+    windowId: string,
+    monitorId: string,
+    responseText: string,
+  ): void {
+    const messageId = `hook-resp-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+    this.handleTask({
+      type: 'monitor',
+      messageId,
+      monitorId,
+      content: `<agent-hook type="response" appId="${appId}" windowId="${windowId}">${responseText || '(no response text)'}</agent-hook>`,
+    }).catch((err) => {
+      console.error('[ContextPool] Hook response delivery failed:', err);
+    });
+  }
+
   // ── Initialization ─────────────────────────────────────────────────
 
   async initialize(existingLogger?: SessionLogger): Promise<boolean> {

--- a/packages/server/src/agents/pool-types.ts
+++ b/packages/server/src/agents/pool-types.ts
@@ -32,6 +32,8 @@ export interface Task {
   interactions?: UserInteraction[];
   actionId?: string; // For parallel button actions
   monitorId?: string; // Which monitor this task belongs to
+  /** One-shot hook: notify the originating agent when this task completes. */
+  hook?: 'response';
 }
 
 /**
@@ -56,4 +58,11 @@ export interface PoolContext {
   // Methods processors call back into
   getOrCreateMonitorQueue(monitorId: string): MonitorQueuePolicy;
   sendEvent(event: ServerEvent): Promise<void>;
+  /** Deliver a hook-triggered response notification to the monitor agent. */
+  notifyHookResponse(
+    appId: string,
+    windowId: string,
+    monitorId: string,
+    responseText: string,
+  ): void;
 }

--- a/packages/server/src/handlers/window.ts
+++ b/packages/server/src/handlers/window.ts
@@ -131,6 +131,11 @@ export function registerWindowHandlers(
         },
         debounceMs: { type: 'number', description: 'Debounce interval in ms (default: 500).' },
         subscriptionId: { type: 'string', description: 'Subscription ID for unsubscribe.' },
+        hook: {
+          type: 'string',
+          enum: ['response'],
+          description: 'Set to "response" to receive a notification when the app agent responds.',
+        },
       },
     },
 
@@ -261,6 +266,7 @@ export function registerWindowHandlers(
           const messageId = `agent-msg-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
           const monitorId = getMonitorId() ?? '0';
           const taggedContent = `<monitor:${monitorId}>\n${p.message as string}\n</monitor:${monitorId}>`;
+          const hook = p.hook === 'response' ? ('response' as const) : undefined;
           pool
             .handleTask({
               type: 'app',
@@ -268,6 +274,7 @@ export function registerWindowHandlers(
               windowId,
               content: taggedContent,
               monitorId,
+              hook,
             })
             .catch((err: unknown) => console.error('[window.message] Failed:', err));
 


### PR DESCRIPTION
When the monitor agent sends a message to an app window via
invoke('yaar://windows/{id}', { action: 'message', hook: 'response' }),
the server now automatically wakes the monitor agent with the app agent's
response once it completes. This eliminates the need for app agents to
explicitly use the relay tool to notify the monitor.

https://claude.ai/code/session_016UFdPb1ev14ovFM2yuvyDR