### PR TITLE
feat(yaar-ml): in-browser model runtime SDK (@bundled/yaar-ml)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -65,6 +65,7 @@
         "mammoth": "^1.9.0",
         "marked": "^17.0.3",
         "matter-js": "^0.20.0",
+        "onnxruntime-web": "^1.27.0",
         "p5": "^2.2.0",
         "pixi.js": "^8.16.0",
         "prismjs": "^1.30.0",
@@ -118,6 +119,7 @@
         "@yaar/compiler": "workspace:*",
         "@yaar/shared": "workspace:*",
         "node-poppler": "^9.1.1",
+        "onnxruntime-web": "1.27.0",
         "qrcode-terminal": "^0.12.0",
         "ssh2": "^1.17.0",
         "ws": "^8.18.0",
@@ -271,6 +273,24 @@
     "@pixi/colord": ["@pixi/colord@2.9.6", "", {}, "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA=="],
 
     "@profoundlogic/hogan": ["@profoundlogic/hogan@3.0.4", "", { "dependencies": { "nopt": "1.0.10" }, "bin": { "hulk": "bin/hulk" } }, "sha512-pmNVGuooS30Mm7YbZd5T7E5zYVO6D5Ct91sn4T39mUvMUc3sCGridcnhAufL1/Bz2QzAtzEn0agNrdk3+5yWzw=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.2", "", {}, "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 
@@ -708,6 +728,8 @@
 
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
+    "flatbuffers": ["flatbuffers@25.9.23", "", {}, "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="],
+
     "flatted": ["flatted@3.3.4", "", {}, "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
@@ -735,6 +757,8 @@
     "globals": ["globals@17.4.0", "", {}, "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "guid-typescript": ["guid-typescript@1.0.9", "", {}, "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="],
 
     "happy-dom": ["happy-dom@20.8.9", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA=="],
 
@@ -846,6 +870,8 @@
 
     "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
     "lop": ["lop@0.4.2", "", { "dependencies": { "duck": "^0.1.12", "option": "~0.2.1", "underscore": "^1.13.1" } }, "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
@@ -906,6 +932,10 @@
 
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
+    "onnxruntime-common": ["onnxruntime-common@1.27.0", "", {}, "sha512-3KxL5wIVqa8Ex08jxSzncm9CMgw8CjOFyOQ7SxvG9o0cVLlhTNKXyIQuTbtX4tGPJEf73OER2xrjt4HJSBL4ow=="],
+
+    "onnxruntime-web": ["onnxruntime-web@1.27.0", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.27.0", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-ogDLsqIozHZwifPuN37OproAo0byX6t43/bP8GzeZWBWD6MOGExswFAx3up4NS/vvWBOg2u2PXomDt3rMmdQSg=="],
+
     "option": ["option@0.2.4", "", {}, "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
@@ -942,6 +972,8 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
+    "platform": ["platform@1.3.6", "", {}, "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="],
+
     "pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
@@ -953,6 +985,8 @@
     "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
+
+    "protobufjs": ["protobufjs@7.6.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 

--- a/docs/app-development.md
+++ b/docs/app-development.md
@@ -129,6 +129,9 @@ Some `@bundled/*` SDKs require explicit opt-in via the `"bundles"` field in `app
 |-----|------------|---------|------------------------|
 | Dev Tools | `@bundled/yaar-dev` | `compile()`, `typecheck()`, `deploy()`, `bundledLibraries()` | `"yaar-dev"` |
 | Browser | `@bundled/yaar-web` | `open()`, `click()`, `type()`, `extract()`, etc. | `"yaar-web"` |
+| ML runtime | `@bundled/yaar-ml` | In-browser model inference (WebGPU/wasm): `session()`, `run()`, `capabilities()`, `fetchWeights()` | `"yaar-ml"` |
+
+See [`docs/yaar_ml_runtime.md`](./yaar_ml_runtime.md) for the ML runtime's capabilities, memory limits, and "what fits" guidance.
 
 **app.json:**
 ```json

--- a/docs/tier1_inbrowser_models_plan.md
+++ b/docs/tier1_inbrowser_models_plan.md
@@ -1,0 +1,172 @@
+# Tier 1 — In-Browser Native Models (WebGPU / ONNX) Plan
+
+**Goal:** let a YAAR app run a model *inside the app iframe* — no Python server, no
+install — using WebGPU (with a wasm fallback). This makes YAAR apps able to ship
+their own model and run it anywhere the desktop runs, including remote/headless mode.
+
+---
+
+## Status
+
+**Workstream A (`@bundled/yaar-ml`) — ✅ shipped.** The reusable in-browser runtime
+is implemented and verified end-to-end. Milestone 1's platform half ("a YAAR app
+runs a model, no Python") is done. See [`yaar_ml_runtime.md`](./yaar_ml_runtime.md).
+
+- Runtime SDK shim `packages/compiler/src/shims/yaar-ml.ts` — wraps
+  `onnxruntime-web` (v1.27): `capabilities()`, `session()` (WebGPU→wasm auto),
+  `run()`, `fetchWeights()` (IndexedDB-cached + progress), `clearCache()`,
+  `dispose()`, `Tensor`/`env`/`ort`. Gated behind `app.json` `"bundles": ["yaar-ml"]`
+  (automatic via the existing `yaar-*` guard in `plugins.ts`).
+- Bundled types for `@bundled/yaar-ml` (self-contained; typecheck passes).
+- Static artifact route `GET /api/ml-runtime/{file}` serves ORT's `.wasm`/`.mjs`
+  (`getMlRuntimeDir()` in server `config.ts`; immutable-cached; traversal-guarded).
+- **Design correction:** deployed apps run under CSP `connect-src 'self'`, so
+  weights can't be fetched cross-origin directly and `/api/fetch` caps at 10 MB
+  base64. Added a same-origin **streaming** proxy `GET /api/ml-weights?url=…`
+  (SSRF + domain-allowlist enforced, forwards `Content-Length`/`ETag`/`Range`,
+  no double-buffering). The shim routes weight downloads through it.
+- Verified live: gating (fail w/o `bundles`, 424 KB bundle w/ it), artifact route
+  (200 `application/wasm` immutable; traversal→400; missing→404), weights proxy
+  (400 on missing url / SSRF; real HuggingFace file streamed with headers intact),
+  typecheck + lint + prettier clean.
+
+**Not yet done (follow-ups):**
+- **Workstream B** — the `anima-turbo-handy` app (SD-Turbo smoke test) has not
+  been built yet.
+- **Exe bundling** — `getMlRuntimeDir()` resolves `./ml-runtime/` next to a
+  bundled exe, but `scripts/build-exe-bundle.js` does not yet copy the ORT
+  artifacts there. Dev mode works today; exe-mode ML needs that copy step.
+- **A2** — classifier smoke test → SD-Turbo in-browser validation run.
+
+---
+
+**Non-goal (Tier 2/3):** frontier models needing CUDA/MPS + the full Python stack.
+Tier 1 is deliberately scoped to models small enough to download and fit in a
+browser tab's memory.
+
+---
+
+## 1. Feasibility (verified against the codebase)
+
+| Concern | Finding | Consequence |
+|---|---|---|
+| App origin | Apps served same-origin at `/api/apps/{id}/dist/index.html` (`features/dev/deploy.ts`, `features/browser/actions.ts:85`) — a real URL, not `srcdoc` | `fetch()`, IndexedDB, `navigator.gpu` all behave normally |
+| CSP | HTML wrapper (`compiler/src/compile.ts:106`) sets **no** `Content-Security-Policy` | wasm + WebGPU are not blocked |
+| Cross-origin isolation | No COOP/COEP headers | **No `SharedArrayBuffer`** → ORT *multithreaded wasm* unavailable. **WebGPU EP needs neither** → primary path unaffected; single-thread wasm is the fallback |
+| Bundled SDK hook | `@bundled/*` has a gated-SDK path (`yaar-web`/`yaar-dev`) enforced via `app.json` `"bundles"` in `plugins.ts` | Add the ML runtime the same way — clean, already-permissioned |
+| Runtime artifacts | ORT ships `.wasm` / WebGPU JS artifacts loaded at runtime from a URL; they **cannot** be inlined by `Bun.build` | Must serve them from a static route and point `ort.env.wasm.wasmPaths` at it |
+| iframe `allow` | `IframeRenderer.tsx:308` sets `allow="accelerometer; autoplay; clipboard-write; …"` | WebGPU works in **same-origin** iframes by default; add a guard + feature-detect. Extend `allow` only if a Chrome version gates it |
+| Big weights | `curl_allowed_domains.yaml` currently `allow_all_domains: true`; HF `resolve` URLs send CORS headers | Fetch weights **directly** in-iframe (not via `yaar://http`, to avoid double-buffering 100s of MB), cache in IndexedDB |
+
+**Verdict:** the platform can host in-browser models today with two additions — a
+gated ML-runtime SDK, and a static route for its wasm/webgpu artifacts. No changes
+to CSP or the compiler HTML wrapper are required.
+
+---
+
+## 2. Two workstreams (keep them separate)
+
+### A. Platform capability — `@bundled/yaar-ml` (reusable, ship first)
+
+The generic runtime any future app can use. Deliverables:
+
+1. **Runtime SDK shim** `packages/compiler/src/shims/yaar-ml.ts`, registered in
+   `BUNDLED_SHIMS` + `BUNDLED_LIBRARIES` and gated behind `app.json` `"bundles": ["yaar-ml"]`
+   (mirror the `yaar-web` enforcement in `plugins.ts`). It wraps **onnxruntime-web**
+   and exposes a tiny, YAAR-flavored API:
+   - `ml.session(modelUrl, { backend: 'webgpu' | 'wasm' | 'auto' })` → cached `InferenceSession`
+   - `ml.run(session, feeds)` → outputs
+   - `ml.fetchWeights(url, { onProgress })` → ArrayBuffer, **IndexedDB-cached** (keyed by URL+etag)
+   - `ml.capabilities()` → `{ webgpu: bool, f16: bool, maxBufferSize, estMemoryBudget }`
+   - Auto-selects WebGPU, falls back to single-thread wasm; surfaces a clear error
+     if a model exceeds `maxStorageBufferBindingSize`.
+2. **Bundled types** `packages/compiler/src/bundled-types/` entry so `bun run typecheck` sees `@bundled/yaar-ml`.
+3. **Static artifact route** — serve ORT's `.wasm`/webgpu JS from e.g.
+   `/api/ml-runtime/*` (server static handler; `config.ts` already maps mime types).
+   Shim sets `ort.env.wasm.wasmPaths = '/api/ml-runtime/'`. Ship the artifacts with
+   the repo / bundled exe so it works offline.
+4. **Weight cache + progress** — IndexedDB store with an eviction budget; a reusable
+   `DownloadProgress` helper so apps get a real progress bar on first load.
+5. **Capability/limits doc** — one page on tab-memory ceilings, WebGPU buffer limits,
+   quantization guidance, and "what fits" (whisper-tiny, small SD-Turbo, embedders,
+   classifiers). Silent OOM must become a friendly "this model is too big for your GPU".
+
+**Model to validate the pipeline first — NOT Anima.** Pick a model that already has a
+working ONNX + in-browser story so the platform lands independently of the hard
+export work. Recommended: **SD-Turbo (ONNX, int8) via onnxruntime-web WebGPU** — it's
+on-theme (image gen), a known-good browser target, and proves the whole path
+(download → cache → WebGPU session → image out). A trivial classifier/embedder can be
+the smoke test before SD-Turbo.
+
+### B. The `anima-turbo-handy` app (product, ships against A)
+
+A Solid.js app (`apps/anima-turbo-handy/`) using `@bundled/yaar-ml`:
+
+- **UI:** prompt / negative / steps / cfg / seed / resolution form; live progress bar
+  driven by the scheduler step callback; result gallery.
+- **First release runs SD-Turbo** (works the day Workstream A lands).
+- **Storage:** history + generated images via `appStorage`.
+- **Agent control:** `app.json` (`"bundles": ["yaar-ml"]`) + `SKILL.md` so the monitor
+  agent can generate from natural language ("draw a snowy 1girl") through the app
+  protocol; `command`/`query` verbs expose `generate` + `getResult`.
+- **Model swap later:** switch the model URL from SD-Turbo to the Anima ONNX bundle
+  produced by Workstream C — the app code doesn't change.
+
+### C. Anima ONNX export spike (the hard tail — parallel, offline, Python)
+
+This is the research-grade part; it must **not** block A or B.
+
+1. Bake the Turbo LoRA into the base offline — you already have this
+   (`../krea/anima_lora.py`, the delta-merge). Exported model = "merged Anima", no
+   runtime LoRA.
+2. Export transformer + **Qwen2D VAE** + text encoder to ONNX. Cosmos-style DiTs don't
+   export cleanly — expect custom-op wrangling and opset pinning.
+3. Quantize to int8 (weights) / f16 (compute); **validate numerics** against the MPS
+   reference — flow-match/er_sde scheduler reimplemented in JS must match.
+4. Fit within WebGPU buffer limits; shard weights if needed.
+5. Deliverable: a `.onnx` bundle + JS scheduler the app can point at. **Accept up front
+   that quality/speed will regress vs native MPS** — Tier 1's price for portability.
+
+---
+
+## 3. Sequencing
+
+```
+A1 runtime shim + artifact route + weight cache   ─┐
+A2 smoke test (classifier) → SD-Turbo in-browser   ├─ Milestone 1: "a YAAR app runs a model, no Python"
+B  anima-turbo-handy shipping on SD-Turbo          ─┘
+                                                    
+C  Anima ONNX export spike (parallel, offline)     ── Milestone 2: swap SD-Turbo → Anima, same app
+```
+
+Milestone 1 is a real, demoable platform capability on its own. Milestone 2 delivers
+*your* model, and only it carries the porting risk.
+
+---
+
+## 4. Risks / open questions
+
+- **Memory ceiling.** A quantized DiT + VAE + text encoder may still blow a browser
+  tab's budget on lower-end GPUs. Mitigation: capability gate + graceful "too big"
+  message; keep Tier 2 (native venv) as the escape hatch for big models.
+- **First-load UX.** 100s of MB download on first run. Mitigation: IndexedDB cache +
+  honest progress UI; consider pre-warming.
+- **Numerics drift.** Quantization + JS scheduler will not bit-match MPS. Mitigation:
+  validation harness in Workstream C; treat as a quality budget, not a bug.
+- **WebGPU availability in the iframe.** Same-origin should be fine; verify across the
+  `IframeRenderer` `allow` list and target Chrome versions before committing.
+- **Runtime bundle size.** onnxruntime-web + wasm artifacts are several MB; served
+  once from `/api/ml-runtime/`, cached by the browser — acceptable, but note it in the
+  exe-bundle size.
+- **Which runtime?** onnxruntime-web (WebGPU EP) is the safe default. `transformers.js`
+  is friendlier for HF models but adds a layer; `webgpu`-native ports (MLC) are fastest
+  but per-model. Recommend ORT-web for the generic SDK, revisit per hot model.
+
+---
+
+## 5. What this unlocks beyond one app
+
+The `@bundled/yaar-ml` runtime is the reusable win: any future app can embed a small
+model — on-device whisper transcription, semantic search embeddings, background
+removal, image classification, small SD variants — with zero install and full
+portability into remote mode. "Anima Turbo Handy" is the first customer, not the point.

--- a/docs/yaar_ml_runtime.md
+++ b/docs/yaar_ml_runtime.md
@@ -1,0 +1,113 @@
+# `@bundled/yaar-ml` — In-Browser Model Runtime
+
+Run a model *inside a YAAR app iframe* — no Python, no install — using WebGPU
+(with a single-thread wasm fallback). Weights download once and cache in the
+browser, so an ML app ships its model and runs anywhere the desktop runs,
+including remote/headless mode.
+
+This is **Tier 1** from [`tier1_inbrowser_models_plan.md`](./tier1_inbrowser_models_plan.md):
+models small enough to download and fit in a browser tab. Frontier models that
+need CUDA/MPS are out of scope (that's the native Tier 2/3 path).
+
+The SDK is **gated** — declare it in `app.json`:
+
+```json
+{ "bundles": ["yaar-ml"] }
+```
+
+---
+
+## Quick start
+
+```typescript
+import { capabilities, session, run, Tensor } from '@bundled/yaar-ml';
+
+const caps = await capabilities();
+if (!caps.webgpu) console.warn('No WebGPU — falling back to (slower) wasm');
+
+// Downloads + caches weights, creates a WebGPU session (wasm fallback in `auto`).
+const s = await session('https://huggingface.co/<repo>/resolve/main/model.onnx', {
+  backend: 'auto',
+  onProgress: (p) => console.log(`${(p.ratio * 100) | 0}%`),
+});
+
+const input = new Tensor('float32', new Float32Array(1 * 3 * 224 * 224), [1, 3, 224, 224]);
+const out = await run(s, { pixel_values: input });
+console.log(out);
+```
+
+## API
+
+| Function | Purpose |
+|---|---|
+| `capabilities()` | `{ webgpu, f16, maxBufferSize, maxStorageBufferBindingSize, estMemoryBudget, adapter }`. Never throws; cached. |
+| `session(model, opts?)` | Create (or return a memoized) `InferenceSession` from a model **URL** or raw `ArrayBuffer`/`Uint8Array`. `opts.backend`: `'webgpu' \| 'wasm' \| 'auto'` (default `auto`). `opts.onProgress` reports weight download. |
+| `run(session, feeds, options?)` | Run inference. `feeds` maps input names → `Tensor`. Resolves to the output map. |
+| `fetchWeights(url, opts?)` | Download weights as an `ArrayBuffer`, IndexedDB-cached by URL, streamed with `opts.onProgress`. `opts.force` re-downloads. |
+| `clearCache(url?)` | Evict one cached weight file, or the whole cache. |
+| `dispose(session)` | Release a session's native resources. |
+| `Tensor`, `env`, `ort` | onnxruntime-web's `Tensor` constructor, `env` (advanced tuning), and the raw namespace. |
+
+## How it works (platform plumbing)
+
+- **Runtime artifacts.** onnxruntime-web loads its `.wasm` binaries at runtime.
+  The SDK points `ort.env.wasm.wasmPaths` at `/api/ml-runtime/`, a static route
+  the server serves from the installed `onnxruntime-web/dist` (immutable, hard-cached).
+- **Weights.** Deployed apps run under CSP `connect-src 'self'`, so the SDK
+  fetches weights through the same-origin **streaming** proxy `/api/ml-weights?url=…`
+  instead of hitting the model host cross-origin. The proxy enforces SSRF
+  protection + the `curl_allowed_domains.yaml` allowlist and streams the body
+  through (no base64 double-buffering of hundreds of MB). The result is cached
+  in IndexedDB keyed by URL (HuggingFace `resolve` URLs are revision-pinned, so
+  they're treated as immutable — pass `force: true` to refresh).
+- **Single-thread.** YAAR iframes are not cross-origin isolated (no COOP/COEP),
+  so `SharedArrayBuffer` — and thus multithreaded wasm — is unavailable. The SDK
+  pins `numThreads = 1`. The **WebGPU** execution provider does not need threads,
+  so the primary path is unaffected; single-thread wasm is only the fallback.
+
+## Capabilities & limits — "what fits"
+
+Tier 1 is bounded by two ceilings:
+
+1. **GPU buffer limits.** `capabilities().maxStorageBufferBindingSize` is the
+   hard per-tensor ceiling (often ~128 MB–2 GB depending on the GPU). A single
+   weight/activation buffer larger than this cannot be allocated. If a model
+   exceeds it, `session()` throws a friendly *"this model is too big for your
+   GPU"* error rather than a silent OOM. Mitigation: pick a smaller or more
+   heavily quantized model, or shard weights.
+2. **Tab memory.** The whole model + activations must fit the tab's budget.
+   Low-end GPUs and mobile fall over well before desktop.
+
+**Known-good targets** (download → cache → WebGPU → output):
+
+- Embedders / semantic search (e.g. all-MiniLM, int8) — tens of MB.
+- Image classifiers (MobileNet/ResNet ONNX) — tens of MB.
+- Small speech (whisper-tiny/base) — on-device transcription.
+- Background removal (U²-Net / MODNet).
+- Small diffusion (SD-Turbo int8) — the plan's pipeline-validation target.
+
+Prefer **int8 weights / f16 compute**. Check `capabilities().f16` before relying
+on half-precision; not every adapter exposes `shader-f16`.
+
+## First-load UX
+
+The first run downloads 10s–100s of MB. Always wire `onProgress` to a real
+progress bar; subsequent loads are served from IndexedDB (offline-capable). The
+IndexedDB cache self-evicts oldest-first past a ~4 GB budget.
+
+## Gotchas
+
+- **Feature-detect first.** Call `capabilities()` and degrade gracefully when
+  `webgpu` is false — `backend: 'auto'` already falls back to wasm, but wasm is
+  much slower, so tell the user.
+- **Allowlist.** If `allow_all_domains` is off, add the model host to
+  `config/curl_allowed_domains.yaml` or the weights download returns 403.
+- **Bundle size.** onnxruntime-web's JS glue adds ~400 KB to a compiled app; the
+  `.wasm` artifacts (13–27 MB) are served once from `/api/ml-runtime/` and cached
+  by the browser.
+
+## Server / config knobs
+
+- `YAAR_ML_RUNTIME_DIR` — override where the ORT `.wasm`/`.mjs` artifacts are
+  served from (defaults to the installed package's `dist/`, or `./ml-runtime/`
+  next to a bundled exe).

--- a/packages/compiler/CLAUDE.md
+++ b/packages/compiler/CLAUDE.md
@@ -28,6 +28,7 @@ src/
     ├── yaar.ts            # Main SDK: verb functions, appStorage, createPersistedSignal, onShortcut
     ├── yaar-dev.ts        # Gated SDK: compile, typecheck, deploy (requires bundles: ["yaar-dev"])
     ├── yaar-web.ts        # Gated SDK: browser automation (requires bundles: ["yaar-web"])
+    ├── yaar-ml.ts         # Gated SDK: in-browser model inference via onnxruntime-web (requires bundles: ["yaar-ml"])
     └── anime.ts           # v3→v4 easing name compat wrapper
 ```
 
@@ -49,7 +50,7 @@ src/
 4. Fallback (`Bun.resolveSync`)
 5. Disk (`bundled-libs/` next to exe)
 
-Gating: `yaar-dev` and `yaar-web` require explicit `"bundles"` in app.json. Solid-js imports from bundled libs are intercepted to prevent duplicate module instances.
+Gating: any `yaar-*` extended SDK (`yaar-dev`, `yaar-web`, `yaar-ml`) requires explicit `"bundles"` in app.json. Solid-js imports from bundled libs are intercepted to prevent duplicate module instances.
 
 **`cssFilePlugin()`** — converts `.css` imports to JS that injects a `<style>` element at runtime.
 
@@ -64,7 +65,7 @@ Gating: `yaar-dev` and `yaar-web` require explicit `"bundles"` in app.json. Soli
 - **Data:** chart.js, d3, diff, diff2html, xlsx, marked, mammoth, prismjs
 - **Animation:** anime (with v3 compat shim)
 - **Audio:** tone
-- **YAAR SDKs:** yaar, yaar-dev (gated), yaar-web (gated)
+- **YAAR SDKs:** yaar, yaar-dev (gated), yaar-web (gated), yaar-ml (gated — in-browser ONNX/WebGPU inference)
 
 ## Shims
 

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -20,6 +20,7 @@
     "@yaar/shared": "workspace:*"
   },
   "devDependencies": {
+    "@e965/xlsx": "^0.20.3",
     "@types/d3": "^7.4.3",
     "@types/lodash-es": "^4.17.12",
     "@types/matter-js": "^0.20.2",
@@ -40,6 +41,7 @@
     "mammoth": "^1.9.0",
     "marked": "^17.0.3",
     "matter-js": "^0.20.0",
+    "onnxruntime-web": "^1.27.0",
     "p5": "^2.2.0",
     "pixi.js": "^8.16.0",
     "prismjs": "^1.30.0",
@@ -47,8 +49,7 @@
     "three": "^0.183.0",
     "tone": "^15.1.22",
     "typescript": "^6.0.2",
-    "uuid": "^13.0.0",
-    "@e965/xlsx": "^0.20.3"
+    "uuid": "^13.0.0"
   },
   "engines": {
     "bun": ">=1.1.22"

--- a/packages/compiler/src/bundled-types/index.d.ts
+++ b/packages/compiler/src/bundled-types/index.d.ts
@@ -439,6 +439,121 @@ declare module '@bundled/yaar-dev' {
   export function bundledLibraries(name: string): Promise<{ name: string; types: string }>;
 }
 
+declare module '@bundled/yaar-ml' {
+  // In-browser model inference via onnxruntime-web (WebGPU EP + wasm fallback).
+  // Requires "bundles": ["yaar-ml"] in app.json.
+
+  export type Backend = 'webgpu' | 'wasm' | 'auto';
+
+  /** A numeric type ORT tensors can hold. */
+  export type MlTensorType =
+    | 'float32'
+    | 'float16'
+    | 'int64'
+    | 'int32'
+    | 'int16'
+    | 'int8'
+    | 'uint8'
+    | 'bool'
+    | 'string';
+
+  /** A minimal onnxruntime-web Tensor. Construct with `new Tensor(...)`. */
+  export interface MlTensor {
+    readonly type: MlTensorType;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    readonly data: any;
+    readonly dims: readonly number[];
+  }
+
+  /** Tensor constructor (subset of onnxruntime-web's Tensor). */
+  export const Tensor: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    new (type: MlTensorType, data: any, dims?: readonly number[]): MlTensor;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    new (data: any, dims?: readonly number[]): MlTensor;
+  };
+
+  /** An opaque compiled model session. Pass to `run()` / `dispose()`. */
+  export interface InferenceSession {
+    readonly inputNames: readonly string[];
+    readonly outputNames: readonly string[];
+    run(
+      feeds: Record<string, MlTensor>,
+      options?: Record<string, unknown>,
+    ): Promise<Record<string, MlTensor>>;
+    release?(): Promise<void>;
+  }
+
+  export interface MlCapabilities {
+    /** WebGPU adapter available in this tab. */
+    webgpu: boolean;
+    /** Adapter supports `shader-f16` (half-precision compute). */
+    f16: boolean;
+    /** `maxBufferSize` in bytes (0 when no WebGPU). */
+    maxBufferSize: number;
+    /** `maxStorageBufferBindingSize` — the practical per-tensor ceiling, in bytes. */
+    maxStorageBufferBindingSize: number;
+    /** Rough usable single-model GPU budget, in bytes. */
+    estMemoryBudget: number;
+    /** Human-readable adapter description, when available. */
+    adapter?: string;
+  }
+
+  export interface DownloadProgress {
+    loaded: number;
+    total: number;
+    /** loaded/total in [0, 1] (0 when total is unknown). */
+    ratio: number;
+    /** True when served from the IndexedDB cache (no network). */
+    cached?: boolean;
+  }
+
+  export interface FetchWeightsOptions {
+    onProgress?: (p: DownloadProgress) => void;
+    force?: boolean;
+    signal?: AbortSignal;
+  }
+
+  export interface SessionOptions {
+    backend?: Backend;
+    onProgress?: (p: DownloadProgress) => void;
+    signal?: AbortSignal;
+    sessionOptions?: Record<string, unknown>;
+  }
+
+  /** Detect WebGPU/f16 support and GPU buffer limits. Never throws; cached. */
+  export function capabilities(): Promise<MlCapabilities>;
+
+  /** Download weights (IndexedDB-cached, streamed with progress) as an ArrayBuffer. */
+  export function fetchWeights(url: string, opts?: FetchWeightsOptions): Promise<ArrayBuffer>;
+
+  /** Remove one cached weight file, or the whole cache when no URL is given. */
+  export function clearCache(url?: string): Promise<void>;
+
+  /** Create (or return a memoized) session from a model URL or raw bytes. */
+  export function session(
+    model: string | ArrayBuffer | Uint8Array,
+    opts?: SessionOptions,
+  ): Promise<InferenceSession>;
+
+  /** Run inference: `feeds` maps input names to Tensors; resolves to the output map. */
+  export function run(
+    session: InferenceSession,
+    feeds: Record<string, MlTensor>,
+    options?: Record<string, unknown>,
+  ): Promise<Record<string, MlTensor>>;
+
+  /** Release a session's native resources. */
+  export function dispose(session: InferenceSession): Promise<void>;
+
+  /** onnxruntime-web env (advanced tuning). */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export const env: any;
+  /** The raw onnxruntime-web namespace, for APIs not surfaced above. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export const ort: any;
+}
+
 declare module '@bundled/yaar-web' {
   // ── Tab lifecycle ──────────────────────────────────────────────
   /** Create a new browser tab without navigating. */

--- a/packages/compiler/src/plugins.ts
+++ b/packages/compiler/src/plugins.ts
@@ -37,6 +37,7 @@ export const BUNDLED_SHIMS: Record<string, string> = {
   yaar: toForwardSlash(join(SHIMS_DIR, 'yaar.ts')),
   'yaar-dev': toForwardSlash(join(SHIMS_DIR, 'yaar-dev.ts')),
   'yaar-web': toForwardSlash(join(SHIMS_DIR, 'yaar-web.ts')),
+  'yaar-ml': toForwardSlash(join(SHIMS_DIR, 'yaar-ml.ts')),
 };
 
 /**
@@ -79,6 +80,7 @@ export const BUNDLED_LIBRARIES: Record<string, string> = {
   yaar: 'yaar',
   'yaar-dev': 'yaar-dev',
   'yaar-web': 'yaar-web',
+  'yaar-ml': 'yaar-ml',
 };
 
 /**

--- a/packages/compiler/src/shims/yaar-ml.ts
+++ b/packages/compiler/src/shims/yaar-ml.ts
@@ -1,0 +1,416 @@
+// @ts-nocheck — This file runs in browser iframes, not the server.
+/**
+ * Gated SDK for @bundled/yaar-ml.
+ *
+ * Run a model *inside the app iframe* — no Python, no install — via
+ * onnxruntime-web (WebGPU execution provider with a single-thread wasm
+ * fallback). Requires "yaar-ml" in app.json bundles field to import.
+ *
+ * Usage:
+ *   import { session, run, Tensor, capabilities } from '@bundled/yaar-ml';
+ *   const caps = await capabilities();               // { webgpu, f16, ... }
+ *   const s = await session('https://.../model.onnx', {
+ *     backend: 'auto',
+ *     onProgress: (p) => console.log((p.ratio * 100) | 0, '%'),
+ *   });
+ *   const out = await run(s, { input: new Tensor('float32', data, [1, 3, 224, 224]) });
+ *
+ * Model weights are fetched through YAAR's same-origin streaming proxy
+ * (`/api/ml-weights`) so they satisfy the app CSP (`connect-src 'self'`) and
+ * are not double-buffered as base64. First download is cached in IndexedDB.
+ * The ORT `.wasm` runtime artifacts are served from `/api/ml-runtime/`.
+ */
+
+import * as ort from 'onnxruntime-web';
+
+// ── Runtime configuration (runs once on import) ──────────────────────────────
+
+// ORT loads its `.wasm` binaries at runtime from this same-origin static route
+// (served by the server from onnxruntime-web/dist). Must be set before any
+// session is created.
+ort.env.wasm.wasmPaths = '/api/ml-runtime/';
+// YAAR iframes are not cross-origin isolated (no COOP/COEP) → SharedArrayBuffer
+// is unavailable, so multithreaded wasm cannot run. Pin to a single thread; the
+// WebGPU EP does not need threads anyway.
+ort.env.wasm.numThreads = 1;
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type Backend = 'webgpu' | 'wasm' | 'auto';
+
+export interface MlCapabilities {
+  /** WebGPU adapter available in this tab. */
+  webgpu: boolean;
+  /** Adapter supports the `shader-f16` feature (half-precision compute). */
+  f16: boolean;
+  /** `GPUSupportedLimits.maxBufferSize` in bytes (0 when no WebGPU). */
+  maxBufferSize: number;
+  /** `GPUSupportedLimits.maxStorageBufferBindingSize` — the practical per-tensor ceiling. */
+  maxStorageBufferBindingSize: number;
+  /** Rough usable budget for a single model on the GPU, in bytes. */
+  estMemoryBudget: number;
+  /** Human-readable adapter description, when the browser exposes it. */
+  adapter?: string;
+}
+
+export interface DownloadProgress {
+  /** Bytes downloaded so far. */
+  loaded: number;
+  /** Total bytes (0 when the server did not report a Content-Length). */
+  total: number;
+  /** loaded/total in [0, 1] (0 when total is unknown). */
+  ratio: number;
+  /** True once the payload came from the IndexedDB cache (no network). */
+  cached?: boolean;
+}
+
+export interface FetchWeightsOptions {
+  onProgress?: (p: DownloadProgress) => void;
+  /** Re-download and overwrite the cached copy. */
+  force?: boolean;
+  signal?: AbortSignal;
+}
+
+export interface SessionOptions {
+  backend?: Backend;
+  onProgress?: (p: DownloadProgress) => void;
+  signal?: AbortSignal;
+  /** Passed straight through to `InferenceSession.create` (graph/opt flags, etc.). */
+  sessionOptions?: Record<string, unknown>;
+}
+
+// ── Capabilities ─────────────────────────────────────────────────────────────
+
+const NO_WEBGPU: MlCapabilities = {
+  webgpu: false,
+  f16: false,
+  maxBufferSize: 0,
+  maxStorageBufferBindingSize: 0,
+  estMemoryBudget: 0,
+};
+
+let _capsPromise: Promise<MlCapabilities> | undefined;
+
+/**
+ * Detect the tab's ML capabilities. Cached after the first call.
+ * Never throws — returns `webgpu: false` when WebGPU is unavailable.
+ */
+export function capabilities(): Promise<MlCapabilities> {
+  if (_capsPromise) return _capsPromise;
+  _capsPromise = (async () => {
+    const gpu = (navigator as any).gpu;
+    if (!gpu) return NO_WEBGPU;
+    try {
+      const adapter = await gpu.requestAdapter();
+      if (!adapter) return NO_WEBGPU;
+      const f16 = adapter.features?.has?.('shader-f16') ?? false;
+      const limits = adapter.limits ?? {};
+      const maxBufferSize = Number(limits.maxBufferSize ?? 0);
+      const maxStorageBufferBindingSize = Number(limits.maxStorageBufferBindingSize ?? 0);
+      let adapterName: string | undefined;
+      try {
+        const info =
+          adapter.info ??
+          (adapter.requestAdapterInfo ? await adapter.requestAdapterInfo() : undefined);
+        if (info) {
+          adapterName =
+            [info.vendor, info.architecture, info.description].filter(Boolean).join(' ') ||
+            undefined;
+        }
+      } catch {
+        /* adapter info is best-effort */
+      }
+      return {
+        webgpu: true,
+        f16,
+        maxBufferSize,
+        // A single storage buffer is the hard per-tensor ceiling; use it as a
+        // conservative single-model budget for "will it fit" checks.
+        maxStorageBufferBindingSize,
+        estMemoryBudget: maxStorageBufferBindingSize,
+        adapter: adapterName,
+      };
+    } catch {
+      return NO_WEBGPU;
+    }
+  })();
+  return _capsPromise;
+}
+
+// ── IndexedDB weight cache ───────────────────────────────────────────────────
+
+const DB_NAME = 'yaar-ml';
+const DB_VERSION = 1;
+const STORE = 'weights';
+/** Evict oldest entries once the cache exceeds this many bytes. */
+const CACHE_BUDGET_BYTES = 4 * 1024 * 1024 * 1024; // 4 GB
+
+interface CacheRecord {
+  url: string;
+  etag?: string;
+  savedAt: number;
+  size: number;
+  data: ArrayBuffer;
+}
+
+let _dbPromise: Promise<IDBDatabase | null> | undefined;
+
+function openDb(): Promise<IDBDatabase | null> {
+  if (_dbPromise) return _dbPromise;
+  _dbPromise = new Promise((resolve) => {
+    if (typeof indexedDB === 'undefined') {
+      resolve(null);
+      return;
+    }
+    try {
+      const req = indexedDB.open(DB_NAME, DB_VERSION);
+      req.onupgradeneeded = () => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains(STORE)) {
+          const store = db.createObjectStore(STORE, { keyPath: 'url' });
+          store.createIndex('savedAt', 'savedAt');
+        }
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => resolve(null);
+    } catch {
+      resolve(null);
+    }
+  });
+  return _dbPromise;
+}
+
+function idbRequest<T>(req: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function cacheGet(url: string): Promise<CacheRecord | null> {
+  const db = await openDb();
+  if (!db) return null;
+  try {
+    const tx = db.transaction(STORE, 'readonly');
+    const rec = await idbRequest<CacheRecord | undefined>(tx.objectStore(STORE).get(url));
+    return rec ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function cachePut(url: string, data: ArrayBuffer, etag?: string): Promise<void> {
+  const db = await openDb();
+  if (!db) return;
+  const record: CacheRecord = { url, etag, savedAt: Date.now(), size: data.byteLength, data };
+  try {
+    const tx = db.transaction(STORE, 'readwrite');
+    await idbRequest(tx.objectStore(STORE).put(record));
+  } catch {
+    /* best-effort; a full quota just means no cache */
+  }
+  // Enforce the budget lazily, after the write.
+  void evictIfNeeded().catch(() => {});
+}
+
+async function evictIfNeeded(): Promise<void> {
+  const db = await openDb();
+  if (!db) return;
+  const tx = db.transaction(STORE, 'readwrite');
+  const store = tx.objectStore(STORE);
+  const all = await idbRequest<CacheRecord[]>(store.getAll());
+  let total = all.reduce((n, r) => n + (r.size || 0), 0);
+  if (total <= CACHE_BUDGET_BYTES) return;
+  // Oldest first.
+  all.sort((a, b) => a.savedAt - b.savedAt);
+  for (const r of all) {
+    if (total <= CACHE_BUDGET_BYTES) break;
+    store.delete(r.url);
+    total -= r.size || 0;
+  }
+}
+
+/** Remove one cached weight file, or the entire cache when no URL is given. */
+export async function clearCache(url?: string): Promise<void> {
+  const db = await openDb();
+  if (!db) return;
+  const tx = db.transaction(STORE, 'readwrite');
+  await idbRequest(url ? tx.objectStore(STORE).delete(url) : tx.objectStore(STORE).clear());
+}
+
+// ── Weight fetching ──────────────────────────────────────────────────────────
+
+function concatChunks(chunks: Uint8Array[], total: number): ArrayBuffer {
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    out.set(c, offset);
+    offset += c.byteLength;
+  }
+  return out.buffer;
+}
+
+/**
+ * Download model weights as an ArrayBuffer, cached in IndexedDB by URL.
+ *
+ * The fetch goes through YAAR's same-origin streaming proxy so it satisfies the
+ * app CSP and streams (real progress, no base64 blow-up). HuggingFace `resolve`
+ * URLs are revision-pinned and treated as immutable — pass `force: true` to
+ * bypass the cache.
+ */
+export async function fetchWeights(
+  url: string,
+  opts: FetchWeightsOptions = {},
+): Promise<ArrayBuffer> {
+  if (!opts.force) {
+    const cached = await cacheGet(url);
+    if (cached) {
+      opts.onProgress?.({
+        loaded: cached.size,
+        total: cached.size,
+        ratio: 1,
+        cached: true,
+      });
+      return cached.data;
+    }
+  }
+
+  const proxied = '/api/ml-weights?url=' + encodeURIComponent(url);
+  const res = await fetch(proxied, { signal: opts.signal });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    throw new Error(`Failed to download weights (${res.status}): ${detail || res.statusText}`);
+  }
+
+  const total = Number(res.headers.get('content-length') || 0);
+  const etag = res.headers.get('etag') || undefined;
+
+  if (!res.body) {
+    // No streamable body — fall back to a single buffered read.
+    const buf = await res.arrayBuffer();
+    opts.onProgress?.({ loaded: buf.byteLength, total: buf.byteLength, ratio: 1 });
+    await cachePut(url, buf, etag);
+    return buf;
+  }
+
+  const reader = res.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let loaded = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    loaded += value.byteLength;
+    opts.onProgress?.({ loaded, total, ratio: total ? loaded / total : 0 });
+  }
+
+  const buf = concatChunks(chunks, loaded);
+  await cachePut(url, buf, etag);
+  return buf;
+}
+
+// ── Inference sessions ───────────────────────────────────────────────────────
+
+const _sessions = new Map<string, Promise<ort.InferenceSession>>();
+
+async function resolveProviders(backend: Backend): Promise<string[]> {
+  if (backend === 'wasm') return ['wasm'];
+  if (backend === 'webgpu') return ['webgpu'];
+  const caps = await capabilities();
+  return caps.webgpu ? ['webgpu', 'wasm'] : ['wasm'];
+}
+
+function looksLikeMemoryError(err: unknown): boolean {
+  const msg = String((err as Error)?.message ?? err ?? '');
+  return /buffer|storage|size|memory|out of memory|oom|exceed/i.test(msg);
+}
+
+async function createSession(
+  bytes: Uint8Array,
+  backend: Backend,
+  extra?: Record<string, unknown>,
+): Promise<ort.InferenceSession> {
+  const providers = await resolveProviders(backend);
+  try {
+    return await ort.InferenceSession.create(bytes, {
+      executionProviders: providers,
+      ...extra,
+    });
+  } catch (err) {
+    if (providers.includes('webgpu')) {
+      const caps = await capabilities();
+      if (looksLikeMemoryError(err)) {
+        const ceil = caps.maxStorageBufferBindingSize
+          ? `${Math.floor(caps.maxStorageBufferBindingSize / (1024 * 1024))} MB`
+          : 'unknown';
+        throw new Error(
+          `This model is too big for your GPU (max single buffer ≈ ${ceil}). ` +
+            `Try a smaller or more heavily quantized model, or backend: 'wasm'. ` +
+            `(original error: ${String((err as Error)?.message ?? err)})`,
+        );
+      }
+      // Auto mode: fall back to the CPU wasm backend on any WebGPU failure.
+      if (backend === 'auto') {
+        return ort.InferenceSession.create(bytes, { executionProviders: ['wasm'], ...extra });
+      }
+    }
+    throw err;
+  }
+}
+
+/**
+ * Create (or return a cached) InferenceSession from a model URL or raw bytes.
+ *
+ * When `model` is a URL, the resulting session is memoized per URL+backend, so
+ * repeated calls are cheap. Weights download through {@link fetchWeights}
+ * (IndexedDB-cached). WebGPU is preferred in `auto` mode and falls back to wasm.
+ */
+export async function session(
+  model: string | ArrayBuffer | Uint8Array,
+  opts: SessionOptions = {},
+): Promise<ort.InferenceSession> {
+  const backend = opts.backend ?? 'auto';
+
+  if (typeof model === 'string') {
+    const key = `${model}::${backend}`;
+    const existing = _sessions.get(key);
+    if (existing) return existing;
+    const promise = (async () => {
+      const buf = await fetchWeights(model, { onProgress: opts.onProgress, signal: opts.signal });
+      return createSession(new Uint8Array(buf), backend, opts.sessionOptions);
+    })();
+    // Drop the memo if creation fails so a retry can start clean.
+    promise.catch(() => _sessions.delete(key));
+    _sessions.set(key, promise);
+    return promise;
+  }
+
+  const bytes = model instanceof Uint8Array ? model : new Uint8Array(model);
+  return createSession(bytes, backend, opts.sessionOptions);
+}
+
+/** Run inference. `feeds` maps input names to Tensors; returns the output map. */
+export function run(
+  s: ort.InferenceSession,
+  feeds: Record<string, ort.Tensor>,
+  options?: ort.InferenceSession.RunOptions,
+): Promise<ort.InferenceSession.OnnxValueMapType> {
+  return s.run(feeds, options);
+}
+
+/** Release a session's native resources. Also clears it from the URL memo. */
+export async function dispose(s: ort.InferenceSession): Promise<void> {
+  for (const [key, promise] of _sessions) {
+    if ((await promise.catch(() => null)) === s) _sessions.delete(key);
+  }
+  await s.release?.();
+}
+
+// ── Re-exports ───────────────────────────────────────────────────────────────
+
+/** onnxruntime-web Tensor constructor — build model inputs with `new Tensor(...)`. */
+export const Tensor = ort.Tensor;
+/** onnxruntime-web env (advanced tuning: `env.wasm`, `env.webgpu`, `env.logLevel`). */
+export const env = ort.env;
+/** The raw onnxruntime-web namespace, for APIs not surfaced above. */
+export { ort };

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,6 +19,7 @@
     "@yaar/compiler": "workspace:*",
     "@yaar/shared": "workspace:*",
     "node-poppler": "^9.1.1",
+    "onnxruntime-web": "1.27.0",
     "qrcode-terminal": "^0.12.0",
     "ssh2": "^1.17.0",
     "ws": "^8.18.0",

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -101,6 +101,46 @@ export const MIME_TYPES: Record<string, string> = {
 
 export const MAX_UPLOAD_SIZE = 50 * 1024 * 1024; // 50MB
 
+/**
+ * Directory holding the onnxruntime-web runtime artifacts (`.wasm`/`.mjs`),
+ * served to app iframes at `/api/ml-runtime/` for the @bundled/yaar-ml SDK.
+ *
+ * - Environment override: `YAAR_ML_RUNTIME_DIR`
+ * - Bundled exe: `./ml-runtime/` alongside the executable (shipped at build time)
+ * - Development: resolved from the installed `onnxruntime-web` package's `dist/`
+ *
+ * Returns `null` when the runtime can't be located (route then 404s cleanly).
+ */
+let _mlRuntimeDir: string | null | undefined;
+export function getMlRuntimeDir(): string | null {
+  if (_mlRuntimeDir !== undefined) return _mlRuntimeDir;
+
+  if (process.env.YAAR_ML_RUNTIME_DIR) {
+    _mlRuntimeDir = process.env.YAAR_ML_RUNTIME_DIR;
+    return _mlRuntimeDir;
+  }
+  if (IS_BUNDLED_EXE) {
+    const dir = join(dirname(process.execPath), 'ml-runtime');
+    _mlRuntimeDir = existsSync(dir) ? dir : null;
+    return _mlRuntimeDir;
+  }
+  // Dev: locate the onnxruntime-web package and point at its dist/.
+  for (const from of [__dirname, PROJECT_ROOT, join(PROJECT_ROOT, 'packages', 'server')]) {
+    try {
+      const pkgJson = Bun.resolveSync('onnxruntime-web/package.json', from);
+      const dist = join(dirname(pkgJson), 'dist');
+      if (existsSync(dist)) {
+        _mlRuntimeDir = dist;
+        return _mlRuntimeDir;
+      }
+    } catch {
+      /* try next base dir */
+    }
+  }
+  _mlRuntimeDir = null;
+  return _mlRuntimeDir;
+}
+
 const DEFAULT_PORT = getEnvInt('PORT', 8000);
 
 /** Current server port (may differ from default if the default was in use). */

--- a/packages/server/src/http/routes/index.ts
+++ b/packages/server/src/http/routes/index.ts
@@ -3,6 +3,7 @@ export { handleBridgeRoutes } from './bridge.js';
 export { handleBrowserRoutes } from './browser.js';
 export { handleDevRoutes } from './dev.js';
 export { handleFileRoutes } from './files.js';
+export { handleMlRuntimeRoutes } from './ml-runtime.js';
 export { handleProxyRoutes } from './proxy.js';
 export { handleSessionRoutes } from './sessions.js';
 export { handleSettingsRoutes } from './settings.js';

--- a/packages/server/src/http/routes/ml-runtime.ts
+++ b/packages/server/src/http/routes/ml-runtime.ts
@@ -1,0 +1,142 @@
+/**
+ * ML runtime routes for the @bundled/yaar-ml SDK.
+ *
+ * - `GET /api/ml-runtime/<file>` — serve onnxruntime-web's `.wasm`/`.mjs`
+ *   artifacts (the SDK points `ort.env.wasm.wasmPaths` here). Static, immutable,
+ *   long-cached.
+ * - `GET /api/ml-weights?url=<url>` — same-origin *streaming* proxy for model
+ *   weights. Satisfies the app CSP (`connect-src 'self'`) and streams the body
+ *   through without base64 double-buffering, so 100s of MB stay cheap. Enforces
+ *   SSRF protection and the domain allowlist.
+ */
+
+import { join, basename, extname } from 'path';
+import { getMlRuntimeDir, MIME_TYPES } from '../../config.js';
+import { errorResponse, type EndpointMeta } from '../utils.js';
+import { validateUrl, safeFetch } from '../../lib/ssrf.js';
+import { extractDomain, isDomainAllowed } from '../../features/config/domains.js';
+
+export const PUBLIC_ENDPOINTS: EndpointMeta[] = [
+  {
+    method: 'GET',
+    path: '/api/ml-runtime/{file}',
+    response: 'file',
+    description: 'onnxruntime-web runtime artifacts (wasm/mjs) for @bundled/yaar-ml',
+  },
+  {
+    method: 'GET',
+    path: '/api/ml-weights?url={url}',
+    response: 'file',
+    description: 'Streaming proxy for ML model weights (same-origin, no base64)',
+  },
+];
+
+/** Only ORT artifact file names — never nested paths. Blocks traversal. */
+const ML_RUNTIME_FILE = /^[A-Za-z0-9._-]+\.(wasm|mjs|js)$/;
+
+export async function handleMlRuntimeRoutes(req: Request, url: URL): Promise<Response | null> {
+  if (url.pathname.startsWith('/api/ml-runtime/')) {
+    return serveRuntimeArtifact(req, url);
+  }
+  if (url.pathname === '/api/ml-weights') {
+    return proxyWeights(req, url);
+  }
+  return null;
+}
+
+// ── Static runtime artifacts ─────────────────────────────────────────────────
+
+async function serveRuntimeArtifact(req: Request, url: URL): Promise<Response> {
+  if (req.method !== 'GET' && req.method !== 'HEAD')
+    return errorResponse('Method not allowed', 405);
+
+  const dir = getMlRuntimeDir();
+  if (!dir) return errorResponse('ML runtime not available', 404);
+
+  // Take only the final path segment and validate it — no directory traversal.
+  const name = basename(decodeURIComponent(url.pathname.slice('/api/ml-runtime/'.length)));
+  if (!ML_RUNTIME_FILE.test(name)) return errorResponse('Invalid runtime file', 400);
+
+  const file = Bun.file(join(dir, name));
+  if (!(await file.exists())) return errorResponse('Not found', 404);
+
+  const ext = extname(name).toLowerCase();
+  const contentType =
+    ext === '.wasm'
+      ? 'application/wasm'
+      : ext === '.mjs' || ext === '.js'
+        ? 'application/javascript'
+        : MIME_TYPES[ext] || 'application/octet-stream';
+
+  return new Response(req.method === 'HEAD' ? null : file, {
+    headers: {
+      'Content-Type': contentType,
+      // HEAD sends a null body; report the real size so size probes work.
+      'Content-Length': String(file.size),
+      // Artifacts are versioned with the onnxruntime-web package — safe to cache hard.
+      'Cache-Control': 'public, max-age=31536000, immutable',
+    },
+  });
+}
+
+// ── Streaming weights proxy ──────────────────────────────────────────────────
+
+async function proxyWeights(req: Request, url: URL): Promise<Response> {
+  if (req.method !== 'GET' && req.method !== 'HEAD')
+    return errorResponse('Method not allowed', 405);
+
+  const target = url.searchParams.get('url');
+  if (!target) return errorResponse('Missing "url" query parameter', 400);
+
+  // SSRF guard (scheme + private-network block).
+  try {
+    validateUrl(target);
+  } catch (err) {
+    return errorResponse(err instanceof Error ? err.message : 'Invalid URL', 400);
+  }
+
+  // Domain allowlist — do not silently exfiltrate to arbitrary hosts.
+  const domain = extractDomain(target);
+  if (!(await isDomainAllowed(domain))) {
+    return errorResponse(
+      `Domain "${domain}" is not allowed. Add it to config/curl_allowed_domains.yaml ` +
+        `(or set allow_all_domains: true) to download weights from it.`,
+      403,
+    );
+  }
+
+  // Forward Range so browsers can resume/segment large downloads.
+  const range = req.headers.get('range');
+  const upstreamHeaders: Record<string, string> = {};
+  if (range) upstreamHeaders['Range'] = range;
+
+  let upstream: Response;
+  try {
+    upstream = await safeFetch(target, { method: 'GET', headers: upstreamHeaders });
+  } catch (err) {
+    return errorResponse(
+      `Failed to fetch weights: ${err instanceof Error ? err.message : String(err)}`,
+      502,
+    );
+  }
+
+  if (!upstream.ok && upstream.status !== 206) {
+    return errorResponse(`Upstream returned ${upstream.status} ${upstream.statusText}`, 502);
+  }
+
+  // Stream the body straight through — no buffering, no base64.
+  const headers: Record<string, string> = {
+    'Content-Type': upstream.headers.get('content-type') || 'application/octet-stream',
+    'Cache-Control': 'no-store',
+    'Access-Control-Expose-Headers': 'Content-Length, ETag, Accept-Ranges, Content-Range',
+  };
+  for (const h of ['content-length', 'etag', 'accept-ranges', 'content-range', 'last-modified']) {
+    const v = upstream.headers.get(h);
+    if (v) headers[h] = v;
+  }
+
+  return new Response(req.method === 'HEAD' ? null : upstream.body, {
+    status: upstream.status,
+    headers,
+  });
+}

--- a/packages/server/src/http/server.ts
+++ b/packages/server/src/http/server.ts
@@ -25,6 +25,7 @@ import {
   handleBrowserRoutes,
   handleDevRoutes,
   handleFileRoutes,
+  handleMlRuntimeRoutes,
   handleProxyRoutes,
   handleSessionRoutes,
   handleSettingsRoutes,
@@ -38,6 +39,7 @@ import { PUBLIC_ENDPOINTS as BRIDGE_PUBLIC } from './routes/bridge.js';
 import { PUBLIC_ENDPOINTS as BROWSER_PUBLIC } from './routes/browser.js';
 import { PUBLIC_ENDPOINTS as DEV_PUBLIC } from './routes/dev.js';
 import { PUBLIC_ENDPOINTS as FILES_PUBLIC } from './routes/files.js';
+import { PUBLIC_ENDPOINTS as ML_RUNTIME_PUBLIC } from './routes/ml-runtime.js';
 import { PUBLIC_ENDPOINTS as PROXY_PUBLIC } from './routes/proxy.js';
 import { PUBLIC_ENDPOINTS as SESSIONS_PUBLIC } from './routes/sessions.js';
 import { PUBLIC_ENDPOINTS as SETTINGS_PUBLIC } from './routes/settings.js';
@@ -61,6 +63,7 @@ function buildPublicRoutes(): PublicRoute[] {
     ...BROWSER_PUBLIC,
     ...DEV_PUBLIC,
     ...FILES_PUBLIC,
+    ...ML_RUNTIME_PUBLIC,
     ...PROXY_PUBLIC,
     ...SESSIONS_PUBLIC,
     ...SETTINGS_PUBLIC,
@@ -228,6 +231,9 @@ export function createFetchHandler() {
 
     const verbResponse = await handleVerbRoutes(req, url);
     if (verbResponse) return withCors(verbResponse, corsHeaders);
+
+    const mlRuntimeResponse = await handleMlRuntimeRoutes(req, url);
+    if (mlRuntimeResponse) return withCors(mlRuntimeResponse, corsHeaders);
 
     const fileResponse = await handleFileRoutes(req, url);
     if (fileResponse) return withCors(fileResponse, corsHeaders);


### PR DESCRIPTION
Workstream A of the Tier 1 in-browser models plan: a reusable, gated SDK that runs ONNX models inside an app iframe via onnxruntime-web (WebGPU EP with a single-thread wasm fallback) — no Python, no install, portable into remote/headless mode.

- shim wraps onnxruntime-web: capabilities(), session() (webgpu→wasm auto), run(), fetchWeights() (IndexedDB-cached + progress), clearCache(), dispose()
- gated behind app.json "bundles": ["yaar-ml"] (existing yaar-* guard)
- self-contained @bundled/yaar-ml type declarations
- GET /api/ml-runtime/{file} serves ORT wasm/mjs artifacts (immutable, guarded)
- GET /api/ml-weights?url=… same-origin streaming weights proxy: satisfies the app CSP (connect-src 'self'), enforces SSRF + domain allowlist, forwards Content-Length/ETag/Range, no base64 double-buffering
- docs: yaar_ml_runtime.md (capabilities/limits), app-development + CLAUDE updates