### PR TITLE
fix(auth): exempt /api/ml-runtime/ from remote auth — ORT cannot send a token

### DIFF
--- a/packages/server/src/http/auth.ts
+++ b/packages/server/src/http/auth.ts
@@ -32,6 +32,22 @@ export function checkHttpAuth(req: Request, url: URL): Response | null {
   // MCP endpoints have their own bearer token auth — exempt from remote auth
   if (url.pathname.startsWith('/mcp/')) return null;
 
+  // onnxruntime-web's own .mjs/.wasm artifacts. onnxruntime fetches these itself, from
+  // the URL it was handed in `ort.env.wasm.wasmPaths`, and there is no hook to attach a
+  // token to those requests — so a gate here does not protect them, it just means
+  // `@bundled/yaar-ml` cannot work at all in REMOTE mode. Every bundled exe is REMOTE
+  // (IS_REMOTE || IS_BUNDLED_EXE), which made that *every installed build*: ORT's import
+  // 401'd and the app rendered a blank window.
+  //
+  // Safe to open, and narrowly: this prefix reaches one route that serves inert,
+  // publicly-published onnxruntime artifacts out of a fixed directory, `basename()`d and
+  // name-checked (`ML_RUNTIME_FILE`) so it cannot be walked. It holds nothing of the
+  // user's. This is NOT the extension-based hole isStaticAsset describes below — the
+  // credential here is the *route*, not a suffix the caller chose, and it deliberately
+  // stops short of `/api/ml-weights*`, which proxies caller-named URLs and writes to
+  // disk (that one stays gated on the yaar-ml bundle).
+  if (url.pathname.startsWith('/api/ml-runtime/')) return null;
+
   // Static frontend assets must load without auth so the client-side JS
   // can read the #remote=<token> hash fragment and attach it to API/WS calls.
   if (isStaticAsset(url.pathname)) return null;

--- a/packages/tests/src/integration/ml-runtime-remote-auth.test.ts
+++ b/packages/tests/src/integration/ml-runtime-remote-auth.test.ts
@@ -1,0 +1,73 @@
+/**
+ * REMOTE mode must not gate onnxruntime's own artifacts.
+ *
+ * `@bundled/yaar-ml` was unreachable in every installed build, and this gate is why.
+ * `IS_REMOTE = process.env.REMOTE === '1' || IS_BUNDLED_EXE` — so a bundled exe is
+ * *always* remote — and `isStaticAsset()` refuses everything under `/api/`, so
+ * `/api/ml-runtime/*` demanded a token. onnxruntime fetches those artifacts itself
+ * from `ort.env.wasm.wasmPaths` and has no hook to attach one, so the import 401'd
+ * and the app rendered a blank window. The route had always *believed* it was open
+ * ("they stay open — there is nothing behind them to protect"); nothing checked that
+ * the gate above it agreed.
+ *
+ * **These tests run the gate in a REMOTE=1 subprocess, and that is the whole point.**
+ * `IS_REMOTE` is captured at module load, so a test in this process — where REMOTE is
+ * unset — gets `checkHttpAuth` returning null on its first line, and every assertion
+ * passes no matter what the gate does. The neighbouring cases in `http-routing.test.ts`
+ * are exactly that, and say so themselves ("IS_REMOTE is still false in test, so auth
+ * is no-op"): they would not have caught this bug, and did not.
+ *
+ * `/api/apps` is asserted alongside for that reason — it is the canary. If it ever
+ * comes back 200, REMOTE didn't take in the subprocess and these results mean nothing.
+ */
+import { describe, it, expect } from 'bun:test';
+import { join } from 'path';
+
+/** Ask the real `checkHttpAuth`, in a process where REMOTE=1 actually took effect. */
+function probeUnderRemote(): Record<string, number> {
+  const script = `
+    const { checkHttpAuth, generateRemoteToken } = await import('@yaar/server/http/auth');
+    generateRemoteToken();
+    const probe = (p) => checkHttpAuth(new Request('http://x' + p), new URL('http://x' + p))?.status ?? 200;
+    console.log(JSON.stringify({
+      mlRuntimeLoader: probe('/api/ml-runtime/ort.webgpu.bundle.min.mjs'),
+      mlRuntimeGlue: probe('/api/ml-runtime/ort-wasm-simd-threaded.asyncify.mjs'),
+      mlRuntimeWasm: probe('/api/ml-runtime/ort-wasm-simd-threaded.asyncify.wasm'),
+      apps: probe('/api/apps'),
+      weights: probe('/api/ml-weights?url=https://host/model.onnx'),
+      weightsDownload: probe('/api/ml-weights/download'),
+    }));
+  `;
+  const proc = Bun.spawnSync(['bun', '-e', script], {
+    cwd: join(import.meta.dir, '..', '..'),
+    env: { ...process.env, REMOTE: '1' },
+  });
+  const out = proc.stdout.toString().trim();
+  if (!proc.success) throw new Error(`probe failed: ${proc.stderr.toString()}`);
+  return JSON.parse(out);
+}
+
+describe('REMOTE auth and /api/ml-runtime/', () => {
+  const status = probeUnderRemote();
+
+  it('has REMOTE genuinely in effect — otherwise nothing below means anything', () => {
+    expect(status.apps).toBe(401);
+  });
+
+  it('serves the ORT artifacts without a token, since ORT cannot send one', () => {
+    // All three: the module the app imports, and the glue + wasm that ORT itself
+    // fetches from wasmPaths. The glue is what surfaced the bug — the loader was
+    // cached (the route sets immutable, max-age=1y) so only the uncached file 401'd.
+    expect(status.mlRuntimeLoader).toBe(200);
+    expect(status.mlRuntimeGlue).toBe(200);
+    expect(status.mlRuntimeWasm).toBe(200);
+  });
+
+  it('does not open the weight routes, which take a caller-named URL', () => {
+    // The exemption is for inert, publicly-published artifacts under a fixed name
+    // check. /api/ml-weights* proxies an arbitrary URL and streams it to disk — it
+    // stays gated, on the remote token here and on the yaar-ml bundle in the route.
+    expect(status.weights).toBe(401);
+    expect(status.weightsDownload).toBe(401);
+  });
+});


### PR DESCRIPTION
v0.10.4 put the onnxruntime artifacts inside the exe. **They still don't load.** Every one of them 401s in an installed build, so `@bundled/yaar-ml` remains dead and anima still opens blank.

## Cause

`IS_REMOTE = process.env.REMOTE === '1' || IS_BUNDLED_EXE` — a bundled exe is **always** remote — and `isStaticAsset()` refuses everything under `/api/`, so `/api/ml-runtime/*` demands the remote token. onnxruntime fetches those artifacts *itself*, from the URL it was handed in `ort.env.wasm.wasmPaths`, and there is no hook to attach a header. The route has always said so in its own comment ("they stay open — there is nothing behind them to protect"); nothing checked that the gate above it agreed. Same shape as the last release's bug: **a stated intent that no code implements.**

## Why the symptom moved instead of vanishing

`extractToken()` falls back to `Referer`, and an app iframe is loaded with `?token=…`. So the token is inherited exactly one hop:

| fetch | Referer | result |
|---|---|---|
| app module `import()`s the ORT loader | iframe URL **with** token | 200 |
| ORT `import()`s its asyncify glue | the **ORT script** — no token | **401** |
| app SDK fetches weights | iframe URL **with** token | 200 |

Hence `Failed to fetch dynamically imported module: .../ort-wasm-simd-threaded.asyncify.mjs` with no error on the loader itself. Reproduced exactly against the pre-fix gate. It also means the weights routes need no exemption — there's no next domino.

## The change

Exempt in `checkHttpAuth`, alongside `/health` and `/mcp/`, **not** in `isStaticAsset` — that predicate's invariant ("nothing under `/api/` is ever a static asset") is deliberate hardening, because remote auth used to be bypassable by choosing a filename, and this must not weaken it. The exemption is a *route*, not a suffix the caller picks.

**This does weaken a gate, deliberately and narrowly.** In REMOTE mode an unauthenticated caller can now `GET /api/ml-runtime/<name>.{wasm,mjs,js}`: inert, publicly-published onnxruntime files from a fixed directory, `basename()`d and name-checked against `ML_RUNTIME_FILE` so the path cannot be walked. Nothing of the user's is behind it. It stops short of `/api/ml-weights*`, which proxies a caller-named URL and writes to disk — that stays gated. The alternative is that yaar-ml cannot work in any installed build, which is the status quo.

## Verification

Live `REMOTE=1` server, **no token** (how ORT fetches):

```
ort.webgpu.bundle.min.mjs              200  application/javascript  113035B
ort-wasm-simd-threaded.asyncify.mjs    200  application/javascript   47507B
ort-wasm-simd-threaded.asyncify.wasm   200  application/wasm      24254953B
/api/apps                              401   ← canary
/api/ml-weights?url=...                401
/api/storage/x.mjs                     401   ← name-based probe still refused
```

The test runs the gate in a `REMOTE=1` **subprocess**, and that is the point: `IS_REMOTE` is captured at module load, so the existing cases in `http-routing.test.ts` assert against a process where REMOTE is unset — `checkHttpAuth` returns null on its first line and they pass no matter what the gate does. They say so themselves ("IS_REMOTE is still false in test, so auth is no-op"), and they did not catch this. `/api/apps` is asserted alongside as the canary. **Confirmed the test fails when the fix is reverted.**

Suites green: server 415, @yaar/tests 89, typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)