### PR TITLE
fix(exe): pass the Linux WebGPU flags when opening the app window

### DIFF
--- a/packages/server/src/exe-entry.ts
+++ b/packages/server/src/exe-entry.ts
@@ -16,6 +16,7 @@ import { ready } from './main.js';
 
 import { getRemoteToken } from './http/auth.js';
 import { getPort } from './config.js';
+import { LINUX_WEBGPU_FLAGS } from './lib/browser/webgpu-flags.js';
 import { hideConsole } from './hide-console.js';
 
 /**
@@ -103,6 +104,12 @@ function openAppWindow() {
       '--disable-default-apps',
       '--disable-features=TranslateUI',
       '--no-first-run',
+      // Without these, `yaar` and `make claude-dev` disagree about whether WebGPU
+      // exists — same machine, same GPU, same app — because dev.sh passes them and
+      // this launcher did not. Linux only; see webgpu-flags.ts. The visible-window
+      // set: the headless pool's extra flags would disable the surface this window
+      // presents through.
+      ...(currentPlatform === 'linux' ? LINUX_WEBGPU_FLAGS : []),
     ];
 
     console.log(`Opening app window: ${chromium} ${args.join(' ')}`);

--- a/packages/server/src/lib/browser/chrome.ts
+++ b/packages/server/src/lib/browser/chrome.ts
@@ -10,6 +10,7 @@ import { existsSync } from 'fs';
 import { mkdtemp, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { LINUX_WEBGPU_FLAGS_HEADLESS } from './webgpu-flags.js';
 import type { Subprocess } from 'bun';
 
 import { createServer } from 'net';
@@ -159,25 +160,12 @@ export async function launchChrome(chromePath: string): Promise<ChromeInstance> 
     '--disable-dev-shm-usage',
     // WebGPU is off by default in Linux Chrome (it needs the Vulkan backend,
     // which is soft-blocklisted there), so yaar-ml inference in the sandbox
-    // fails with "Failed to get GPU adapter". Opt in explicitly — this is the
-    // flag set Chrome's docs recommend for WebGPU under headless. Linux-only:
-    // Windows/macOS enable WebGPU by default, and --use-angle=vulkan would
-    // break macOS (no Vulkan) and downgrade Windows (D3D11 is the default).
-    //
-    // vulkan_enable_f16_on_nvidia: Dawn withholds shader-f16 on all NVIDIA
-    // Vulkan adapters pending CTS failures (crbug.com/42251215) even when the
-    // driver advertises full fp16 support — which is why fp16 models work on
-    // Windows (D3D12) and macOS (Metal) but not here. The toggle lifts that
-    // hold; it is consulted only for NVIDIA, so it's a no-op elsewhere.
-    ...(process.platform === 'linux'
-      ? [
-          '--enable-unsafe-webgpu',
-          '--enable-features=Vulkan',
-          '--use-angle=vulkan',
-          '--disable-vulkan-surface',
-          '--enable-dawn-features=vulkan_enable_f16_on_nvidia',
-        ]
-      : []),
+    // fails with "Failed to get GPU adapter". Opt in explicitly — the headless
+    // set, which adds --use-angle=vulkan/--disable-vulkan-surface to what a
+    // visible window gets. Linux-only: Windows/macOS enable WebGPU by default,
+    // and --use-angle=vulkan would break macOS (no Vulkan) and downgrade
+    // Windows (D3D11 is the default). See webgpu-flags.ts for the rest.
+    ...(process.platform === 'linux' ? LINUX_WEBGPU_FLAGS_HEADLESS : []),
     // New headless still creates a real (hidden) browser window. When the
     // server runs elevated on Windows, Chrome de-elevates by relaunching
     // itself (--do-not-de-elevate) and the relaunched instance can show that

--- a/packages/server/src/lib/browser/webgpu-flags.ts
+++ b/packages/server/src/lib/browser/webgpu-flags.ts
@@ -1,0 +1,43 @@
+/**
+ * Chrome command-line flags that make WebGPU usable on Linux.
+ *
+ * WebGPU is off by default in Linux Chrome — it needs the Vulkan backend, which is
+ * soft-blocklisted there — so `@bundled/yaar-ml` gets "Failed to get GPU adapter" and
+ * falls back to (much slower) single-thread wasm, or fails outright. Windows and macOS
+ * enable WebGPU by default and need none of this.
+ *
+ * `vulkan_enable_f16_on_nvidia`: Dawn withholds shader-f16 on every NVIDIA Vulkan
+ * adapter pending CTS failures (crbug.com/42251215), even where the driver advertises
+ * full fp16 support — which is why fp16 models run on Windows (D3D12) and macOS (Metal)
+ * but not here. The toggle lifts that hold and is consulted only for NVIDIA, so it is a
+ * no-op elsewhere. Dawn toggles have no `chrome://flags` entry, so the command line is
+ * the only way to set it.
+ *
+ * Every launcher that opens a *visible* Chrome for a human to use YAAR in wants exactly
+ * this set, and there are three of them (`scripts/dev.sh`, `exe-entry.ts`, and the
+ * headless pool in `chrome.ts`, which adds its own). The exe's launcher shipped without
+ * them, so `yaar` and `make claude-dev` disagreed about whether WebGPU worked — same
+ * machine, same GPU, same app.
+ *
+ * `scripts/dev.sh` is bash and cannot import this; it keeps its own copy. Change one,
+ * change both.
+ */
+export const LINUX_WEBGPU_FLAGS = [
+  '--enable-unsafe-webgpu',
+  '--enable-features=Vulkan',
+  '--enable-dawn-features=vulkan_enable_f16_on_nvidia',
+];
+
+/**
+ * The above, plus what only a *headless* Chrome wants.
+ *
+ * `--use-angle=vulkan` and `--disable-vulkan-surface` belong to the offscreen pool: the
+ * surface flag disables the very thing a visible window presents through, so a launcher
+ * that opens a real window must not borrow them. This is why the two sets are named
+ * separately rather than one being spread into the other by default.
+ */
+export const LINUX_WEBGPU_FLAGS_HEADLESS = [
+  ...LINUX_WEBGPU_FLAGS,
+  '--use-angle=vulkan',
+  '--disable-vulkan-surface',
+];

--- a/packages/server/src/tests/webgpu-flags.test.ts
+++ b/packages/server/src/tests/webgpu-flags.test.ts
@@ -1,0 +1,42 @@
+/**
+ * The Linux WebGPU flag sets, and the line between them.
+ *
+ * Three launchers open a Chrome that YAAR's ML apps run in, and they disagreed: the
+ * exe's launcher (`exe-entry.ts`) shipped with no GPU flags at all, so WebGPU worked
+ * under `make claude-dev` and not under `yaar` — same machine, same GPU, same app.
+ * Linux Chrome soft-blocklists the Vulkan backend WebGPU needs, so the flags are not
+ * a tuning knob; without them there is no adapter.
+ *
+ * Two things are worth pinning. That the visible-window set stays a *subset* of the
+ * headless one — they must not drift into two unrelated lists. And that it never
+ * acquires `--disable-vulkan-surface`, which is the trap: it reads like a companion to
+ * the other Vulkan flags, and it would disable the surface a visible window presents
+ * through. `scripts/dev.sh` holds a bash copy this cannot reach; its comment carries
+ * the pointer.
+ */
+import { describe, it, expect } from 'bun:test';
+import { LINUX_WEBGPU_FLAGS, LINUX_WEBGPU_FLAGS_HEADLESS } from '../lib/browser/webgpu-flags.js';
+
+describe('LINUX_WEBGPU_FLAGS', () => {
+  it('turns WebGPU on and lifts the NVIDIA fp16 hold', () => {
+    // The three dev.sh has passed all along, and the exe now passes too.
+    expect(LINUX_WEBGPU_FLAGS).toEqual([
+      '--enable-unsafe-webgpu',
+      '--enable-features=Vulkan',
+      '--enable-dawn-features=vulkan_enable_f16_on_nvidia',
+    ]);
+  });
+
+  it('never carries the headless-only surface flags into a visible window', () => {
+    expect(LINUX_WEBGPU_FLAGS).not.toContain('--disable-vulkan-surface');
+    expect(LINUX_WEBGPU_FLAGS).not.toContain('--use-angle=vulkan');
+  });
+
+  it('is what the headless set builds on, not a separate list', () => {
+    for (const flag of LINUX_WEBGPU_FLAGS) {
+      expect(LINUX_WEBGPU_FLAGS_HEADLESS).toContain(flag);
+    }
+    expect(LINUX_WEBGPU_FLAGS_HEADLESS).toContain('--use-angle=vulkan');
+    expect(LINUX_WEBGPU_FLAGS_HEADLESS).toContain('--disable-vulkan-surface');
+  });
+});

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -98,6 +98,11 @@ launch_chrome_when_ready() {
   # to set it — which is why this lives here and not in setup-webgpu-linux.sh.
   # Only takes effect when this actually starts a new Chrome: if one with this
   # profile is already running, close it and re-run to pick up the flags.
+  # Keep in sync with LINUX_WEBGPU_FLAGS in
+  # packages/server/src/lib/browser/webgpu-flags.ts, which the exe's launcher uses —
+  # bash cannot import it, so this is a copy. They disagreed once already: the exe
+  # shipped with no GPU flags at all, so WebGPU worked under `make claude-dev` and not
+  # under `yaar`, on the same machine.
   local gpu_flags=()
   [ "$(uname -s)" = "Linux" ] && gpu_flags=(--enable-unsafe-webgpu --enable-features=Vulkan
     --enable-dawn-features=vulkan_enable_f16_on_nvidia)


### PR DESCRIPTION
`yaar` and `make claude-dev` disagreed about whether WebGPU existed — **same machine, same GPU, same app.** `scripts/dev.sh` has always passed the Linux WebGPU flags when it opens Chrome; `exe-entry.ts`'s `openAppWindow()` passed none, so the installed binary opened a Chrome with no GPU adapter and `yaar-ml` either fell back to single-thread wasm or failed outright.

Linux Chrome soft-blocklists the Vulkan backend WebGPU needs, so these flags are not a tuning knob — without them there is no adapter at all.

## Measured

Same Chrome, same page, fresh profile both times, on an NVIDIA Blackwell:

| launch | result |
|---|---|
| **without** flags (how `yaar` opened Chrome) | `navigator.gpu` exists but **NO ADAPTER** |
| **with** `LINUX_WEBGPU_FLAGS` (how it opens now) | **`ADAPTER nvidia/blackwell  f16=true`** |

The f16 half matters as much as the adapter: Dawn withholds `shader-f16` on every NVIDIA Vulkan adapter (crbug.com/42251215), so without the dawn toggle an fp16 model gets an adapter that silently lacks the feature it needs.

## Why the exe and not a checkout

The exe hands Chrome a **fresh temp profile per launch**. `dev.sh` reuses `~/.yaar-chrome`, where `setup-webgpu-linux.sh` persists the same toggles into Local State — so a dev checkout can appear to work on the profile alone. A throwaway profile has only what the command line gives it.

## The change

Single-source the two TypeScript copies in `lib/browser/webgpu-flags.ts`:

- `LINUX_WEBGPU_FLAGS` — visible window (`exe-entry.ts`)
- `LINUX_WEBGPU_FLAGS_HEADLESS` — those **plus** `--use-angle=vulkan` / `--disable-vulkan-surface`, for the offscreen pool in `chrome.ts`

Kept as two named sets rather than one: `--disable-vulkan-surface` disables the very thing a visible window presents through, so the app-window launcher must not borrow it. That's the trap this encodes — it reads like a companion to the other Vulkan flags. `dev.sh` is bash and cannot import them, so it keeps its copy plus a pointer comment.

## Verification

Against a **real built exe**, not just the constants: the spawned browser process carries `--enable-unsafe-webgpu --enable-features=Vulkan --enable-dawn-features=vulkan_enable_f16_on_nvidia`, and neither headless-only flag.

Suites green: server 418 + 31 loopback + 10 integration, @yaar/tests 89, typecheck + lint clean, `bash -n dev.sh` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)