### PR TITLE
feat(agents): persona agents — app-spawned, tool-less AI instances

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,23 @@ When a user interacts with an app window, a **persistent app agent** is created 
 
 Key files: `agents/app-task-processor.ts` (routing), `agents/agent-pool.ts` (lifecycle), `agents/profiles/app-agent.ts` (prompt builder), `mcp/app-agent/` (describe/query/command/relay tools), `features/apps/discovery.ts` (`controls` parsing + bundled-only guard).
 
+### Persona Agents (app-spawned AI instances)
+
+An app that declares `"personas": { "max": N }` in `app.json` (bundled apps only, like `controls`/`streams`) can spawn up to N **persona agents** from its iframe: tool-less AI instances, each with a system prompt the app supplies at runtime, each its own provider session with its own conversation memory. This is what lets one app run several distinct characters at once rather than one agent role-playing them in turn.
+
+```ts
+invoke('yaar://apps/self/agents', { action: 'spawn', personaId, systemPrompt, model? })
+// → { personaId, instanceId, streamUri }   — idempotent; an existing persona comes back with reused: true
+invoke(`yaar://apps/self/agents/${id}`, { action: 'message', content })   // returns immediately
+invoke(`yaar://apps/self/agents/${id}`, { action: 'interrupt' })
+stream(streamUri, onFrame)      // start | text | thinking | done (carries final text) | error
+list('yaar://apps/self/agents') // roster + max      del(...) // dispose one, or all
+```
+
+Needs `"yaar://apps/self/agents/"` in `permissions` and `"streams": ["agents"]` to watch them. `message` returns as soon as the turn is queued, so N personas generate concurrently. Personas hold **no tools, no MCP servers, no permissions, and no principal** — the runtime-supplied prompt never gets hands — and are reclaimed when the app's last window on that monitor closes. Persistence is the app's job (`appDb`/`appStorage`); a respawned persona gets its history replayed in its first message.
+
+Key files: `agents/profiles/persona.ts` (tool-less profile), `agents/agent-pool.ts` (`spawnPersonaAgent`/`runPersonaTurn`/dispose), `handlers/apps/agents-resource.ts` (the verb surface + ownership check), `features/apps/discovery.ts` (`personas` parsing). Reference consumer: `apps/personas` (Round Table). Design notes: [`docs/proposals/persona_agents_proposal.md`](./docs/proposals/persona_agents_proposal.md).
+
 ### Compiler & Bundled Libraries
 
 Apps are compiled via Bun into a single self-contained HTML file. Entry point is always `src/main.ts`. The compiler injects design tokens, SDK scripts (capture, storage, verb, app-protocol, etc.), and the bundled code.

--- a/apps/personas/HINT.md
+++ b/apps/personas/HINT.md
@@ -1,0 +1,6 @@
+Round Table (`personas`) runs a room of AI characters, each its own tool-less agent with
+its own prompt and memory, all answering at once. Open it when the user wants several
+distinct viewpoints on the same thing at the same time — a devil's advocate plus a
+builder plus a stylist — rather than one assistant listing perspectives. Use its
+`addCharacter` command to cast someone on request ("make me a grumpy pirate"); the prompt
+you write is used verbatim as that character's system prompt.

--- a/apps/personas/SKILL.md
+++ b/apps/personas/SKILL.md
@@ -1,0 +1,38 @@
+# Round Table
+
+A room of AI characters. Each character is a **persona agent**: a tool-less AI instance
+with its own system prompt and its own conversation memory, spawned by this app and
+streamed into it token by token. When the user says something, every character onstage
+answers at the same time — they are separate agents, not one agent taking turns.
+
+## What you can do here
+
+- `addCharacter({ characterId, name, emoji, prompt })` — write a new character into the
+  cast. `prompt` is used verbatim as that character's system prompt, so write it in the
+  second person ("You are Vera, a relentless skeptic…") and say how long its answers
+  should be. It does not go onstage until the user brings it on.
+- `removeCharacter({ characterId })` — drop a character from the cast.
+- `setPrompt({ characterId, prompt })` — rewrite a character's prompt. It takes effect the
+  next time that character goes onstage: a live persona keeps the prompt it was spawned
+  with, because that prompt is replayed on every turn and swapping it mid-conversation
+  would rewrite who the character has been all along.
+- `query('room')` — the cast, who is onstage, and the transcript.
+
+## Writing a good character
+
+The prompt is the character. A vague prompt produces a character that sounds like every
+other character in the room, which defeats the point of running four of them.
+
+- Name the disposition, not the topic: "you look for the assumption nobody stated" beats
+  "you are good at analysis".
+- Say the length. Without it, three characters answering at once buries the user.
+- Give it something to refuse. A character that agrees with the room adds nothing to it.
+
+## Limits
+
+Four characters can be onstage at once (`personas.max` in app.json), and each one holds a
+slot out of YAAR's global agent limit. Characters that are not onstage cost nothing — the
+cast is stored in this app's database, the personas are not.
+
+Personas do not survive the window closing. The cast and the transcript do, and a
+character brought back onstage is told what it missed.

--- a/apps/personas/app.json
+++ b/apps/personas/app.json
@@ -1,0 +1,12 @@
+{
+  "icon": "🎭",
+  "name": "Round Table",
+  "description": "A room of AI characters that answer you at the same time, each with its own mind",
+  "run": "dist/index.html",
+  "permissions": ["yaar://apps/self/agents/", "yaar://apps/self/db/"],
+  "streams": ["agents"],
+  "personas": { "max": 4 },
+  "version": "1.0.0",
+  "author": "YAAR",
+  "kind": "system"
+}

--- a/apps/personas/src/agents.ts
+++ b/apps/personas/src/agents.ts
@@ -1,0 +1,170 @@
+/**
+ * The persona client — everything this app knows about `yaar://apps/self/agents`.
+ *
+ * Two verbs and one stream, and the shape of the whole feature falls out of them:
+ *
+ *   invoke('yaar://apps/self/agents', { action: 'spawn', personaId, systemPrompt })
+ *     → { instanceId, streamUri }        one tool-less agent, prompt used verbatim
+ *   invoke('yaar://apps/self/agents/{id}', { action: 'message', content })
+ *     → { taskId }                       returns immediately; the answer streams
+ *   stream(streamUri, onFrame)           text/thinking deltas, then a `done` with
+ *                                        the final text
+ *
+ * `message` returning immediately is what makes the room a *room*: four characters
+ * are fired in one tick and generate genuinely concurrently, each in its own
+ * provider session, rather than taking turns behind one agent. Nothing here awaits
+ * another character.
+ */
+
+import { createSignal } from '@bundled/solid-js';
+import { invoke, list, del, stream, type StreamFrame } from '@bundled/yaar';
+import * as z from '@bundled/zod';
+import type { Character } from './store';
+import {
+  FrameDataSchema,
+  PersonaHandleSchema,
+  RosterSchema,
+  parseOrThrow,
+  type Roster,
+} from './schema';
+
+/** What one character is doing right now. Absent from the map = not spawned. */
+export interface Live {
+  personaId: string;
+  instanceId: string;
+  streamUri: string;
+  /** True from `message` until the turn's terminal frame. */
+  speaking: boolean;
+  /** Accumulated text deltas for the turn in flight. */
+  draft: string;
+  /** Accumulated thinking deltas — shown behind a fold. */
+  thinking: string;
+  /** Highest transcript seq this persona has already been told about. */
+  lastSeq: number;
+  error?: string;
+}
+
+export const [live, setLive] = createSignal<Record<string, Live>>({});
+
+/** Unsubscribe thunks, one per live persona. Not reactive — nothing renders them. */
+const stops = new Map<string, () => void>();
+
+function patch(personaId: string, changes: Partial<Live>): void {
+  const current = live()[personaId];
+  if (!current) return;
+  setLive({ ...live(), [personaId]: { ...current, ...changes } });
+}
+
+/**
+ * Fold one stream frame into the persona's row.
+ *
+ * `text`/`thinking` carry *deltas*, so they append. `start` is the turn boundary —
+ * without clearing there, a second turn's text would be rendered as a continuation
+ * of the first. `done` and `error` are terminals, and `done` carries the turn's
+ * final text, which is preferred over the accumulated draft: it is the
+ * authoritative string, and a dropped delta would otherwise leave a hole nobody
+ * notices.
+ */
+function onFrame(personaId: string, frame: StreamFrame, onDone: (text: string) => void): void {
+  // A frame whose payload doesn't parse is dropped rather than thrown: this runs on
+  // a live wire, and one odd frame must not take the room down with it.
+  const parsed = z.safeParse(FrameDataSchema, frame.data ?? {});
+  if (!parsed.success) {
+    console.warn(`[personas] unreadable ${frame.kind} frame for ${personaId}`, frame.data);
+    return;
+  }
+  const data = parsed.data;
+
+  switch (frame.kind) {
+    case 'start':
+      patch(personaId, { speaking: true, draft: '', thinking: '', error: undefined });
+      break;
+    case 'text':
+      patch(personaId, { draft: (live()[personaId]?.draft ?? '') + (data.content ?? '') });
+      break;
+    case 'thinking':
+      patch(personaId, { thinking: (live()[personaId]?.thinking ?? '') + (data.content ?? '') });
+      break;
+    case 'done': {
+      const text = data.text ?? live()[personaId]?.draft ?? '';
+      patch(personaId, { speaking: false, draft: '' });
+      if (text.trim()) onDone(text.trim());
+      break;
+    }
+    case 'error':
+      patch(personaId, { speaking: false, error: data.error ?? 'stream error' });
+      break;
+  }
+}
+
+/**
+ * Spawn a character's persona and start watching its stream.
+ *
+ * Idempotent on the server — spawning a personaId that already exists hands back
+ * the live one with its memory intact — which is what makes an iframe reload
+ * cheap: call this for every character on mount and the room comes back as it was.
+ */
+export async function spawn(
+  character: Character,
+  onDone: (characterId: string, text: string) => void,
+): Promise<void> {
+  const result = parseOrThrow(
+    PersonaHandleSchema,
+    await invoke('yaar://apps/self/agents', {
+      action: 'spawn',
+      personaId: character.characterId,
+      systemPrompt: character.prompt,
+    }),
+    'spawn',
+  );
+
+  setLive({
+    ...live(),
+    [character.characterId]: {
+      personaId: result.personaId,
+      instanceId: result.instanceId,
+      streamUri: result.streamUri,
+      speaking: false,
+      draft: '',
+      thinking: '',
+      lastSeq: 0,
+    },
+  });
+
+  stops.get(character.characterId)?.();
+  const stop = await stream(
+    result.streamUri,
+    (frame) => onFrame(character.characterId, frame, (text) => onDone(character.characterId, text)),
+    { kinds: ['start', 'text', 'thinking', 'done', 'error'] },
+  );
+  stops.set(character.characterId, stop);
+}
+
+/** Send one persona its turn. Returns as soon as the turn is queued, never awaits it. */
+export async function say(characterId: string, content: string, upToSeq: number): Promise<void> {
+  patch(characterId, { speaking: true, draft: '', thinking: '', lastSeq: upToSeq });
+  try {
+    await invoke(`yaar://apps/self/agents/${characterId}`, { action: 'message', content });
+  } catch (err) {
+    patch(characterId, { speaking: false, error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+export async function interrupt(characterId: string): Promise<void> {
+  await invoke(`yaar://apps/self/agents/${characterId}`, { action: 'interrupt' });
+  patch(characterId, { speaking: false });
+}
+
+export async function dispose(characterId: string): Promise<void> {
+  stops.get(characterId)?.();
+  stops.delete(characterId);
+  await del(`yaar://apps/self/agents/${characterId}`);
+  const next = { ...live() };
+  delete next[characterId];
+  setLive(next);
+}
+
+/** The platform's view of the roster — authoritative if this app's state drifted. */
+export async function roster(): Promise<Roster> {
+  return parseOrThrow(RosterSchema, await list('yaar://apps/self/agents'), 'roster');
+}

--- a/apps/personas/src/main.ts
+++ b/apps/personas/src/main.ts
@@ -1,0 +1,367 @@
+import { createSignal, createMemo, For, Show, onMount } from '@bundled/solid-js';
+import html from '@bundled/solid-js/html';
+import { defineApp, showToast, errMsg } from '@bundled/yaar';
+import * as z from '@bundled/zod';
+
+import {
+  cast,
+  transcript,
+  loadRoom,
+  addCharacter,
+  removeCharacter,
+  updateCharacter,
+  appendLine,
+  clearTranscript,
+  turnPrompt,
+  nextSeq,
+  type Character,
+} from './store';
+import { live, spawn, say, interrupt, dispose, roster } from './agents';
+import './styles.css';
+
+const STARTER_CAST: Array<Pick<Character, 'characterId' | 'name' | 'emoji' | 'prompt'>> = [
+  {
+    characterId: 'skeptic',
+    name: 'Vera',
+    emoji: '🧐',
+    prompt:
+      'You are Vera, a relentless skeptic. You answer in two or three sentences. You look for the ' +
+      'assumption nobody stated and name it. You are never rude, but you never agree just to be agreeable.',
+  },
+  {
+    characterId: 'builder',
+    name: 'Kit',
+    emoji: '🔧',
+    prompt:
+      'You are Kit, a builder. You answer in two or three sentences and always in terms of the ' +
+      'smallest thing that could be made this week. You dislike abstractions with no artifact attached.',
+  },
+  {
+    characterId: 'poet',
+    name: 'Sol',
+    emoji: '🌗',
+    prompt:
+      'You are Sol, who thinks in images. You answer in two or three sentences, concrete and sensory, ' +
+      'and you find the metaphor that makes the idea land. You never explain your own metaphor.',
+  },
+];
+
+function App() {
+  const [draft, setDraft] = createSignal('');
+  const [busy, setBusy] = createSignal(false);
+  const [editing, setEditing] = createSignal<string | null>(null);
+  const [max, setMax] = createSignal(4);
+
+  const spawnedCount = createMemo(() => Object.keys(live()).length);
+  const anySpeaking = createMemo(() => Object.values(live()).some((l) => l.speaking));
+
+  /**
+   * A character finished. Its answer joins the transcript, so the *next* round the
+   * others are told what it said — which is the whole trick behind characters that
+   * appear to talk to each other rather than past each other.
+   */
+  async function onAnswer(characterId: string, text: string) {
+    try {
+      await appendLine(characterId, text);
+    } catch (err) {
+      showToast(errMsg(err), 'error');
+    }
+  }
+
+  async function bringOnstage(character: Character) {
+    try {
+      await spawn(character, onAnswer);
+    } catch (err) {
+      showToast(errMsg(err), 'error');
+    }
+  }
+
+  async function send() {
+    const text = draft().trim();
+    if (!text || busy()) return;
+    const speaking = Object.entries(live());
+    if (speaking.length === 0) {
+      showToast('Bring at least one character onstage first', 'error');
+      return;
+    }
+
+    setBusy(true);
+    try {
+      setDraft('');
+      await appendLine('user', text);
+      const upTo = nextSeq() - 1;
+      // Fired together, deliberately not awaited in sequence: each `say` returns as
+      // soon as its turn is queued, so every character is generating at once.
+      await Promise.all(
+        speaking.map(([characterId, state]) => {
+          const character = cast().find((c) => c.characterId === characterId);
+          if (!character) return Promise.resolve();
+          return say(characterId, turnPrompt(character, state.lastSeq), upTo);
+        }),
+      );
+    } catch (err) {
+      showToast(errMsg(err), 'error');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function stopEveryone() {
+    for (const [characterId, state] of Object.entries(live())) {
+      if (state.speaking) await interrupt(characterId).catch(() => {});
+    }
+  }
+
+  async function addStarterCast() {
+    try {
+      for (const person of STARTER_CAST) {
+        if (!cast().some((c) => c.characterId === person.characterId)) {
+          await addCharacter(person);
+        }
+      }
+    } catch (err) {
+      showToast(errMsg(err), 'error');
+    }
+  }
+
+  onMount(async () => {
+    try {
+      await loadRoom();
+      const state = await roster();
+      setMax(state.max);
+      // Personas already alive from before an iframe reload — reattach their streams
+      // rather than respawning, so nobody loses the conversation they were in.
+      for (const person of state.personas) {
+        const character = cast().find((c) => c.characterId === person.personaId);
+        if (character) await bringOnstage(character);
+      }
+    } catch (err) {
+      showToast(errMsg(err), 'error');
+    }
+  });
+
+  return html`
+    <div class="y-app rt-root">
+      <div class="rt-cast">
+        <div class="y-label">
+          Cast · ${() => spawnedCount()}/${() => max()} onstage
+        </div>
+
+        <${For} each=${cast}>
+          ${(character: Character) => {
+            const state = () => live()[character.characterId];
+            return html`
+              <div class="rt-card" classList=${() => ({ active: !!state() })}>
+                <div class="rt-card-head">
+                  <span class="rt-emoji">${character.emoji}</span>
+                  <span class="rt-name y-truncate">${character.name}</span>
+                  <${Show} when=${() => state()?.speaking}>
+                    <span class="y-spinner rt-spin"></span>
+                  </>
+                </div>
+
+                <${Show}
+                  when=${() => editing() === character.characterId}
+                  fallback=${() =>
+                    html`<div class="rt-prompt y-clamp-3">${character.prompt}</div>`}
+                >
+                  <textarea
+                    class="y-input rt-prompt-edit"
+                    rows="6"
+                    value=${character.prompt}
+                    onChange=${(e: Event) =>
+                      updateCharacter(character.characterId, {
+                        prompt: (e.target as HTMLTextAreaElement).value,
+                      })}
+                  ></textarea>
+                </>
+
+                <div class="rt-card-actions">
+                  <${Show}
+                    when=${() => state()}
+                    fallback=${() => html`
+                      <button
+                        class="y-btn y-btn-primary"
+                        disabled=${() => spawnedCount() >= max()}
+                        onClick=${() => bringOnstage(character)}
+                      >
+                        Onstage
+                      </button>
+                    `}
+                  >
+                    <button class="y-btn y-btn-ghost" onClick=${() => dispose(character.characterId)}>
+                      Offstage
+                    </button>
+                  </>
+                  <button
+                    class="y-btn y-btn-ghost"
+                    onClick=${() =>
+                      setEditing(editing() === character.characterId ? null : character.characterId)}
+                  >
+                    ${() => (editing() === character.characterId ? 'Done' : 'Prompt')}
+                  </button>
+                  <button
+                    class="y-btn y-btn-danger"
+                    onClick=${async () => {
+                      if (live()[character.characterId]) await dispose(character.characterId);
+                      await removeCharacter(character.characterId);
+                    }}
+                  >
+                    ✕
+                  </button>
+                </div>
+
+                <${Show} when=${() => state()?.error}>
+                  <div class="rt-error">${() => state()?.error}</div>
+                </>
+              </div>
+            `;
+          }}
+        </>
+
+        <${Show} when=${() => cast().length === 0}>
+          <div class="y-empty">
+            <div class="y-empty-icon">🎭</div>
+            <div>No characters yet.</div>
+            <button class="y-btn y-btn-primary" onClick=${addStarterCast}>Add a starter cast</button>
+          </div>
+        </>
+      </div>
+
+      <div class="rt-room">
+        <div class="rt-log">
+          <${For} each=${transcript}>
+            ${(line) => {
+              const who = () =>
+                line.speaker === 'user'
+                  ? { emoji: '🧑', name: 'You' }
+                  : (cast().find((c) => c.characterId === line.speaker) ?? {
+                      emoji: '🎭',
+                      name: line.speaker,
+                    });
+              return html`
+                <div class="rt-line" classList=${() => ({ mine: line.speaker === 'user' })}>
+                  <div class="rt-line-who">
+                    <span class="rt-emoji">${() => who().emoji}</span>
+                    <span>${() => who().name}</span>
+                  </div>
+                  <div class="rt-line-text">${line.text}</div>
+                </div>
+              `;
+            }}
+          </>
+
+          <${For} each=${() => Object.entries(live()).filter(([, s]) => s.speaking)}>
+            ${(entry) => {
+              const [characterId, state] = entry as [string, ReturnType<typeof live>[string]];
+              const character = () => cast().find((c) => c.characterId === characterId);
+              const current = () => live()[characterId];
+              return html`
+                <div class="rt-line pending">
+                  <div class="rt-line-who">
+                    <span class="rt-emoji">${() => character()?.emoji ?? '🎭'}</span>
+                    <span>${() => character()?.name ?? characterId}</span>
+                    <span class="y-spinner rt-spin"></span>
+                  </div>
+                  <${Show} when=${() => current()?.thinking}>
+                    <details class="rt-thinking">
+                      <summary>thinking…</summary>
+                      <div>${() => current()?.thinking}</div>
+                    </details>
+                  </>
+                  <div class="rt-line-text">${() => current()?.draft || '…'}</div>
+                </div>
+              `;
+            }}
+          </>
+
+          <${Show} when=${() => transcript().length === 0 && !anySpeaking()}>
+            <div class="y-empty">
+              <div class="y-empty-icon">💬</div>
+              <div>Bring characters onstage, then say something.</div>
+              <div class="rt-hint">
+                Each one is its own agent with its own memory. They answer at the same time.
+              </div>
+            </div>
+          </>
+        </div>
+
+        <div class="rt-compose">
+          <textarea
+            class="y-input"
+            rows="2"
+            placeholder="Say something to the room…"
+            value=${draft}
+            onInput=${(e: Event) => setDraft((e.target as HTMLTextAreaElement).value)}
+            onKeyDown=${(e: KeyboardEvent) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                void send();
+              }
+            }}
+          ></textarea>
+          <div class="rt-compose-actions">
+            <button class="y-btn y-btn-primary" disabled=${busy} onClick=${send}>Send</button>
+            <${Show} when=${anySpeaking}>
+              <button class="y-btn y-btn-ghost" onClick=${stopEveryone}>Stop</button>
+            </>
+            <button class="y-btn y-btn-ghost" onClick=${clearTranscript}>Clear</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+export default defineApp({
+  id: 'personas',
+  name: 'Round Table',
+  state: {
+    room: {
+      description: 'The cast, who is onstage, and the transcript',
+      get: () => ({
+        cast: cast().map((c) => ({ characterId: c.characterId, name: c.name, emoji: c.emoji })),
+        onstage: Object.entries(live()).map(([characterId, s]) => ({
+          characterId,
+          speaking: s.speaking,
+        })),
+        transcript: transcript().map((l) => ({ speaker: l.speaker, text: l.text })),
+      }),
+    },
+  },
+  commands: {
+    addCharacter: {
+      description: 'Write a new character into the cast (does not bring it onstage)',
+      params: z.object({
+        characterId: z.string(),
+        name: z.string(),
+        emoji: z.string(),
+        prompt: z.string(),
+      }),
+      // Writes a row — replaying it on remount would duplicate the character.
+      replay: 'never',
+      run: async (p) => {
+        await addCharacter(p as Pick<Character, 'characterId' | 'name' | 'emoji' | 'prompt'>);
+        return { added: p.characterId };
+      },
+    },
+    removeCharacter: {
+      description: 'Remove a character from the cast',
+      params: z.object({ characterId: z.string() }),
+      replay: 'never',
+      run: async (p) => {
+        await removeCharacter(p.characterId);
+        return { removed: p.characterId };
+      },
+    },
+    setPrompt: {
+      description: "Rewrite a character's system prompt (takes effect next time it goes onstage)",
+      params: z.object({ characterId: z.string(), prompt: z.string() }),
+      run: async (p) => {
+        await updateCharacter(p.characterId, { prompt: p.prompt });
+        return { updated: p.characterId };
+      },
+    },
+  },
+  view: App,
+});

--- a/apps/personas/src/schema.ts
+++ b/apps/personas/src/schema.ts
@@ -1,0 +1,57 @@
+// Boundary schemas for everything this app is *handed* rather than owns.
+//
+// Two boundaries, and they fail in different ways, which is why they are validated
+// rather than cast:
+//
+//   1. The persona verbs (`yaar://apps/self/agents`). The envelope is JSON parsed
+//      out of a text block by `toEnvelope`, and a malformed one would otherwise be
+//      discovered as `undefined.instanceId` three frames into a stream subscription
+//      — far from the call that produced it.
+//   2. Agent stream frames. `kind` is source-defined and `data` is `unknown` by
+//      declaration; a frame kind gaining a field, or an `error` frame arriving where
+//      `text` was expected, is a normal event on a live wire, not an exception.
+//
+// `@bundled/zod` is Zod Mini (functional API): `z.optional(z.string())`,
+// `z.safeParse(Schema, data)`.
+import * as z from '@bundled/zod';
+
+/** What `spawn` and `message` hand back. Loose — the server may add fields. */
+export const PersonaHandleSchema = z.looseObject({
+  personaId: z.string(),
+  instanceId: z.string(),
+  streamUri: z.string(),
+});
+
+/** The roster from `list('yaar://apps/self/agents')`. */
+export const RosterSchema = z.looseObject({
+  max: z.number(),
+  personas: z.array(z.looseObject({ personaId: z.string(), busy: z.optional(z.boolean()) })),
+});
+
+/**
+ * The `data` payload of the stream frames this app reads.
+ *
+ * Every field optional on purpose: one schema covers `start`, `text`, `thinking`,
+ * `done`, and `error`, and which fields are present is what `kind` already says.
+ * Validating shape rather than presence keeps a new frame kind from being a crash.
+ */
+export const FrameDataSchema = z.looseObject({
+  content: z.optional(z.string()),
+  text: z.optional(z.string()),
+  error: z.optional(z.string()),
+  status: z.optional(z.string()),
+});
+
+export type PersonaHandle = z.infer<typeof PersonaHandleSchema>;
+export type Roster = z.infer<typeof RosterSchema>;
+export type FrameData = z.infer<typeof FrameDataSchema>;
+
+/** Parse or throw with a message naming the call that produced the bad shape. */
+export function parseOrThrow<T>(schema: z.ZodMiniType<T>, value: unknown, what: string): T {
+  const result = z.safeParse(schema, value);
+  if (!result.success) {
+    console.error(`[personas] ${what} failed validation`, result.error.issues, value);
+    throw new Error(`${what} returned an unexpected shape`);
+  }
+  return result.data;
+}

--- a/apps/personas/src/store.ts
+++ b/apps/personas/src/store.ts
@@ -1,0 +1,119 @@
+/**
+ * Cast and transcript — the app's own memory.
+ *
+ * Personas do not survive their window: the platform reclaims them when the last
+ * window closes, because four idle agents holding four of ten global slots is a
+ * cost the user did not ask for. Persistence is therefore *this* file's job, and
+ * the shape below is chosen for that recovery: a character is a row you can respawn
+ * from, and the transcript is a log you can replay into the respawned persona's
+ * first message. Nothing here needs the personas to be alive.
+ */
+
+import { createSignal } from '@bundled/solid-js';
+import { appDb } from '@bundled/yaar';
+
+/** A character as stored. `_id` is the server's, added on read. */
+export interface CharacterDoc {
+  /** Stable across respawns — this is the personaId the platform keys on. */
+  characterId: string;
+  name: string;
+  emoji: string;
+  /** Verbatim system prompt. This *is* the character. */
+  prompt: string;
+  createdAt: number;
+  [key: string]: unknown;
+}
+
+export interface LineDoc {
+  /** Monotonic within the room; what "everything since your last turn" is measured in. */
+  seq: number;
+  /** `user`, or a characterId. */
+  speaker: string;
+  text: string;
+  ts: number;
+  [key: string]: unknown;
+}
+
+export type Character = CharacterDoc & { _id?: string };
+export type Line = LineDoc & { _id?: string };
+
+const characters = appDb.collection<CharacterDoc>('characters');
+const lines = appDb.collection<LineDoc>('lines');
+
+export const [cast, setCast] = createSignal<Character[]>([]);
+export const [transcript, setTranscript] = createSignal<Line[]>([]);
+
+/** Next sequence number. Derived rather than stored — one less thing to keep true. */
+export function nextSeq(): number {
+  const all = transcript();
+  return all.length === 0 ? 1 : all[all.length - 1].seq + 1;
+}
+
+export async function loadRoom(): Promise<void> {
+  const [people, log] = await Promise.all([
+    characters.find({}, { sort: { createdAt: 1 } }),
+    lines.find({}, { sort: { seq: 1 }, limit: 200 }),
+  ]);
+  setCast(people);
+  setTranscript(log);
+}
+
+export type CharacterInput = Pick<CharacterDoc, 'characterId' | 'name' | 'emoji' | 'prompt'>;
+
+export async function addCharacter(input: CharacterInput): Promise<void> {
+  const doc: CharacterDoc = { ...input, createdAt: Date.now() };
+  const _id = await characters.insert(doc);
+  setCast([...cast(), { ...doc, _id }]);
+}
+
+export async function updateCharacter(
+  characterId: string,
+  patch: Partial<CharacterDoc>,
+): Promise<void> {
+  const existing = cast().find((c) => c.characterId === characterId);
+  if (!existing?._id) return;
+  await characters.update(existing._id, patch);
+  setCast(cast().map((c) => (c.characterId === characterId ? { ...c, ...patch } : c)));
+}
+
+export async function removeCharacter(characterId: string): Promise<void> {
+  const existing = cast().find((c) => c.characterId === characterId);
+  if (existing?._id) await characters.remove(existing._id);
+  setCast(cast().filter((c) => c.characterId !== characterId));
+}
+
+export async function appendLine(speaker: string, text: string): Promise<Line> {
+  const line: LineDoc = { seq: nextSeq(), speaker, text, ts: Date.now() };
+  const _id = await lines.insert(line);
+  const stored: Line = { ...line, _id };
+  setTranscript([...transcript(), stored]);
+  return stored;
+}
+
+export async function clearTranscript(): Promise<void> {
+  await lines.removeWhere({ seq: { $gte: 0 } });
+  setTranscript([]);
+}
+
+/**
+ * The turn's prompt for one character: everything said since it last spoke,
+ * speaker-labeled, plus a nudge to stay in character.
+ *
+ * Only the *new* lines are sent. A persona is a real provider session with its own
+ * conversation memory, so replaying the whole transcript every turn would pay for
+ * the same tokens twice and, worse, present the character with a second copy of
+ * things it already said. `sinceSeq` of 0 (a respawn) sends the lot, which is the
+ * recovery path.
+ */
+export function turnPrompt(character: Character, sinceSeq: number): string {
+  const fresh = transcript().filter((l) => l.seq > sinceSeq && l.speaker !== character.characterId);
+  if (fresh.length === 0) return '(Nothing new was said. Say something anyway, briefly.)';
+
+  const label = (speaker: string) =>
+    speaker === 'user' ? 'User' : (cast().find((c) => c.characterId === speaker)?.name ?? speaker);
+
+  return (
+    fresh.map((l) => `${label(l.speaker)}: ${l.text}`).join('\n') +
+    `\n\nReply as ${character.name}, in one short paragraph. Do not narrate, do not prefix your name.`
+  );
+}

--- a/apps/personas/src/styles.css
+++ b/apps/personas/src/styles.css
@@ -1,0 +1,176 @@
+.rt-root {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: var(--yaar-sp-3);
+  padding: var(--yaar-sp-3);
+  overflow: hidden;
+}
+
+/* ── Cast ─────────────────────────────────────────────── */
+
+.rt-cast {
+  display: flex;
+  flex-direction: column;
+  gap: var(--yaar-sp-2);
+  overflow-y: auto;
+  padding-right: var(--yaar-sp-1);
+}
+
+.rt-card {
+  border: 1px solid var(--yaar-border);
+  border-radius: 6px;
+  padding: var(--yaar-sp-2);
+  background: var(--yaar-bg-surface);
+  display: flex;
+  flex-direction: column;
+  gap: var(--yaar-sp-2);
+}
+
+.rt-card.active {
+  border-color: var(--yaar-accent);
+}
+
+.rt-card-head {
+  display: flex;
+  align-items: center;
+  gap: var(--yaar-sp-2);
+}
+
+.rt-emoji {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.rt-name {
+  font-weight: 600;
+  flex: 1;
+}
+
+.rt-spin {
+  width: 12px;
+  height: 12px;
+}
+
+.rt-prompt {
+  font-size: 12px;
+  color: var(--yaar-text-muted);
+  line-height: 1.45;
+}
+
+.rt-prompt-edit {
+  font-size: 12px;
+  line-height: 1.45;
+  resize: vertical;
+}
+
+.rt-card-actions {
+  display: flex;
+  gap: var(--yaar-sp-1);
+}
+
+.rt-card-actions .y-btn {
+  padding: 2px 8px;
+  font-size: 12px;
+}
+
+.rt-error {
+  font-size: 12px;
+  color: var(--yaar-error);
+}
+
+/* ── Room ─────────────────────────────────────────────── */
+
+.rt-room {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--yaar-sp-2);
+  min-width: 0;
+  overflow: hidden;
+}
+
+.rt-log {
+  position: absolute;
+  inset: 0 0 96px 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--yaar-sp-3);
+  padding-right: var(--yaar-sp-2);
+}
+
+.rt-line {
+  display: flex;
+  flex-direction: column;
+  gap: var(--yaar-sp-1);
+}
+
+.rt-line-who {
+  display: flex;
+  align-items: center;
+  gap: var(--yaar-sp-2);
+  font-size: 12px;
+  color: var(--yaar-text-muted);
+}
+
+.rt-line-text {
+  white-space: pre-wrap;
+  line-height: 1.55;
+  border-left: 2px solid var(--yaar-border);
+  padding-left: var(--yaar-sp-3);
+}
+
+.rt-line.mine .rt-line-text {
+  border-left-color: var(--yaar-accent);
+  color: var(--yaar-text);
+}
+
+.rt-line.pending .rt-line-text {
+  color: var(--yaar-text-muted);
+}
+
+.rt-thinking {
+  font-size: 12px;
+  color: var(--yaar-text-muted);
+  padding-left: var(--yaar-sp-3);
+}
+
+.rt-thinking summary {
+  cursor: pointer;
+}
+
+.rt-thinking div {
+  white-space: pre-wrap;
+  opacity: 0.75;
+  margin-top: var(--yaar-sp-1);
+}
+
+.rt-hint {
+  font-size: 12px;
+  color: var(--yaar-text-muted);
+  max-width: 40ch;
+  text-align: center;
+}
+
+/* ── Compose ──────────────────────────────────────────── */
+
+.rt-compose {
+  position: absolute;
+  inset: auto 0 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--yaar-sp-2);
+  background: var(--yaar-bg);
+  padding-top: var(--yaar-sp-2);
+}
+
+.rt-compose textarea {
+  resize: none;
+}
+
+.rt-compose-actions {
+  display: flex;
+  gap: var(--yaar-sp-2);
+}

--- a/apps/process-explorer/src/main.ts
+++ b/apps/process-explorer/src/main.ts
@@ -29,6 +29,9 @@ function typeBadge(type: AgentEntry['type']) {
   const colors: Record<string, string> = {
     monitor: 'var(--yaar-accent)',
     app: 'var(--yaar-success)',
+    // An app's own persona — same family as its app agent, dimmer because a room
+    // of four should read as one app's cast rather than four peers of it.
+    persona: 'color-mix(in srgb, var(--yaar-success) 55%, var(--yaar-text-muted))',
     ephemeral: 'var(--yaar-text-muted)',
     session: '#f5a623',
   };

--- a/apps/process-explorer/src/types.ts
+++ b/apps/process-explorer/src/types.ts
@@ -42,7 +42,7 @@ export interface AgentStats {
  * for a badge colour). A fifth tier from a newer server should render as its own
  * name and behave like a monitor agent — not blank the panel.
  */
-export type AgentTier = 'session' | 'monitor' | 'app' | 'ephemeral' | (string & {});
+export type AgentTier = 'session' | 'monitor' | 'app' | 'persona' | 'ephemeral' | (string & {});
 
 export interface AgentEntry {
   /** instanceId — what the interrupt action takes. */

--- a/docs/proposals/persona_agents_proposal.md
+++ b/docs/proposals/persona_agents_proposal.md
@@ -1,6 +1,7 @@
 # Proposal: Persona Agents — app-spawned AI instances (and a ChitChats-class chat room app)
 
-**Status:** Draft
+**Status:** Phase 1 landed (the primitive). Phase 2/3 (the ChitChats port) not started —
+see [What shipped](#what-shipped) for the delta between this document and the code.
 **Scope:** `packages/server` (agent pool, new verb surface, stream access), `packages/shared` (SDK), one new bundled app (`apps/chitchats`)
 **Driving use case:** porting the feature set of [`chitchats-public`](https://github.com/sorryhyun/chitchats-public) — a multi-character AI chat room — into YAAR as a bundled app.
 
@@ -20,6 +21,31 @@ the user and each other — turn scheduling in the iframe, personas doing the ta
 
 The primitive is the point; the app is the proof. In the OS metaphor, apps (processes)
 finally get threads.
+
+## What shipped
+
+Phase 1 landed close to the design below, in ~600 lines of server code across six files plus
+tests. Where the code differs from this document, the code is right and the difference is here:
+
+| Design (below) | As built | Why |
+|---|---|---|
+| Pool tier keyed `{monitorId}::{appId}::{personaId}` | Same, and the key is never parsed back out — `PersonaAgent` carries `{appId, monitorId, personaId}` as fields | The record shape the multi-window proposal §2 also wants |
+| `spawn` errors when the persona exists | **Idempotent**: hands back the live persona with `reused: true`, ignoring the new prompt | An iframe reload re-runs the app's spawn calls; refusing costs the app its cast, and swapping the prompt under a live conversation rewrites who the persona has been. Delete and respawn to recast |
+| Ownership via `self` resolution | `self` resolution *plus* an appId-in-URI vs. appId-in-context equality check | The permission list says what you may ask for; ownership says whose personas they are. An app cannot forge its context appId, so the second check is the load-bearing one |
+| `done` frame gains `{ text }` | Done — on **every** agent's stream, not just personas | It is the same mapper; an interrupted turn carries its partial text too |
+| Queue-or-reject when busy | **Reject**, with `busy: true` on the envelope | The app's scheduler is the only thing that knows whether a second message is a follow-up or a race |
+| Personas disposed when the app's last window closes | Same, asked of the window registry rather than `AppTaskProcessor.activeWindows` | That map tracks the most-recently-active window and is cleared by the close itself — reading it would report "no windows left" with a second window still open |
+| SDK sugar in `@bundled/yaar` (`yaar.agents.*`) | **Not built.** Apps use `invoke`/`list`/`del` + the existing `yaar.stream()` | The verb calls are already one line each; sugar can follow a second consumer |
+| §1.3 "verify the Claude path drops WebSearch/Task" | Verified and pinned by a test against the real `buildSDKOptions` | `allowedTools: []` yields no MCP servers, no `WebSearch`, no `Task`. `undefined` yields all of them — the test asserts both halves |
+
+Open question 2 (per-persona model tier) is answered by `spawn`'s optional `model`, with no
+default change. Questions 1, 3, 4, and 5 stand as written.
+
+**Not built:** `apps/chitchats` (Phase 2/3). In its place is `apps/personas` ("Round Table"),
+a ~700-line bundled app that is the primitive's proof rather than the ChitChats port: a cast of
+characters, each a persona, all answering one message concurrently with live streaming and a
+thinking fold, persisted in `appDb`. The tape executor, interrupt-weave, `[[skip]]` convergence,
+and per-room scheduling are Phase 2/3 and remain unwritten.
 
 ## Motivation
 

--- a/packages/server/CLAUDE.md
+++ b/packages/server/CLAUDE.md
@@ -155,7 +155,9 @@ SessionHub (singleton registry)
         │   ├── Session Agent: PooledAgent | null            ← lazy singleton; cross-monitor oversight + session principal (only tier with yaar://session/* access; the only principal that drives the user's real browser via yaar://session/browser)
         │   ├── Monitor Agents: Map<monitorId, PooledAgent>  ← one per monitor
         │   ├── Ephemeral Agents (temporary, no context)
-        │   └── App Agents: Map<appId, PooledAgent>  ← persistent per app
+        │   ├── App Agents: Map<appId, PooledAgent>  ← persistent per app
+        │   └── Persona Agents: Map<monitorId::appId::personaId, PersonaAgent>
+        │        ← N per (monitor, app); tool-less, prompt supplied by the app at runtime
         ├── ContextTape (hierarchical message history)
         │   ├── [main] user/assistant messages
         │   └── [window:id] branch messages
@@ -238,6 +240,24 @@ Tools use `actionEmitter.emitAction()` to broadcast actions to frontend and opti
 **Monitor ↔ App Agent Communication:**
 - **Monitor → App**: `invoke('yaar://windows/{id}', { action: 'message', message: '...' })` — wraps message in `<monitor:{monitorId}>` tags and routes as an app task via `AppTaskProcessor`. Fire-and-forget; use `hook: 'response'` to get the app agent's reply back.
 - **App → Monitor**: App agent's `relay` tool enqueues a `type: 'monitor'` task. Additionally, app agent responses are pushed to `InteractionTimeline` and drained by the monitor on its next turn.
+
+**Persona agents (`yaar://apps/self/agents`):** an app that declares `"personas": { "max": N }` in its
+app.json (bundled-only, like `controls`/`streams`) may spawn up to N tool-less AI instances, each with
+a system prompt it supplies at runtime and each its own provider session with its own memory. The verb
+surface lives in `handlers/apps/agents-resource.ts` — `list` / `invoke {spawn|message|interrupt}` /
+`read` / `delete` — and is callable from the app's iframe (`POST /api/verb`), never by another app:
+the appId in the URI must equal the appId the *context* says the caller is, which the caller cannot
+forge. `message` returns as soon as the turn is queued, so N personas generate concurrently; the answer
+arrives on the existing `yaar://agents/{instanceId}/stream` feed (needs `"streams": ["agents"]`), whose
+`done` frame carries the turn's final text.
+
+Personas deliberately hold **no tools, no MCP servers, no permissions, and no principal** —
+`buildPersonaProfile` sets `allowedTools: []`, from which `buildSDKOptions` derives an empty MCP set and
+no builtins. That empty array is the whole containment story for a runtime-supplied prompt; `undefined`
+there would mean *every* tool. They bypass `ContextPool` entirely (no tape, no queue — the app's own
+scheduler serializes them) and are reclaimed when the app's last window on the monitor closes, when the
+monitor is removed, or on explicit `delete`. See `docs/proposals/persona_agents_proposal.md` and
+`apps/personas` (Round Table) for the reference consumer.
 
 ## REST API
 

--- a/packages/server/src/agents/agent-pool.ts
+++ b/packages/server/src/agents/agent-pool.ts
@@ -5,12 +5,15 @@
  * - Monitor agents: persistent per-monitor, handle USER_MESSAGE, provider session continuity
  * - Ephemeral agents: fresh provider, no context, disposed after one task
  * - App agents: persistent per (monitor, app), handle app protocol communication
+ * - Persona agents: N per (monitor, app), tool-less, prompt supplied by the app at runtime
  *
  * Used by ContextPool to decouple agent lifecycle from task orchestration.
  */
 
 import { AgentSession } from './agent-session.js';
 import { getAgentLimiter } from './limiter.js';
+import { personaRole } from './profiles/persona.js';
+import { monitorSource } from './context.js';
 import { acquireWarmProvider } from '../providers/factory.js';
 import { getSessionHub } from '../session/session-hub.js';
 import { notifyAgentsChanged } from '../http/subscriptions.js';
@@ -38,6 +41,16 @@ function parseAppKey(key: string): { monitorId: string; appId: string } {
 }
 
 /**
+ * Persona agents extend the app key with the persona's own id. The parts are never
+ * parsed back out — {@link PersonaAgent} carries them as fields — so the key only
+ * has to be unique, and `::` still cannot occur in any of the three components
+ * (numeric monitorId, directory-name appId, {@link PERSONA_ID_RE} personaId).
+ */
+export function personaAgentKey(monitorId: string, appId: string, personaId: string): string {
+  return `${monitorId}::${appId}::${personaId}`;
+}
+
+/**
  * Internal pooled agent representation.
  */
 export interface PooledAgent {
@@ -53,14 +66,45 @@ export interface PooledAgent {
 export interface AgentEntry {
   /** instanceId — stable across turns; accepted by `interruptByIdOrRole`. */
   id: string;
-  type: 'session' | 'monitor' | 'app' | 'ephemeral';
+  type: 'session' | 'monitor' | 'app' | 'ephemeral' | 'persona';
   /** Human-readable name: the monitorId, the appId, or the current role. */
   label: string;
   busy: boolean;
   monitorId?: string;
   appId?: string;
+  /** Persona agents only — the id its owning app spawned it under. */
+  personaId?: string;
   /** Lifetime token consumption. `inputTokens` is fresh input — see {@link TokenUsage}. */
   usage: TokenUsage;
+}
+
+/**
+ * A persona agent and the metadata its owning app spawned it with.
+ *
+ * The prompt lives here rather than on the provider because a persona's prompt is
+ * *the persona*: it is replayed as `systemPromptOverride` on every turn, and the
+ * provider's own `systemPrompt` (the generic YAAR one it was warmed with) is never
+ * used. Keeping it on the record also means a busy check, a roster row, and a
+ * respawn all read the same object.
+ */
+export interface PersonaAgent {
+  agent: PooledAgent;
+  monitorId: string;
+  appId: string;
+  personaId: string;
+  /** Verbatim, caller-supplied. Replayed on every turn — see {@link buildPersonaProfile}. */
+  systemPrompt: string;
+  model?: string;
+  createdAt: number;
+  /**
+   * Final assistant text of the last completed turn.
+   *
+   * The `done` stream frame carries the same text, so a live subscriber never needs
+   * this. It exists for the subscriber that *wasn't* live: an iframe that reloaded
+   * mid-turn, or one whose subscription dropped, can `read` the persona and recover
+   * the answer instead of re-asking a question the model already paid for.
+   */
+  lastResponse?: string;
 }
 
 const ZERO_USAGE: TokenUsage = {
@@ -93,6 +137,15 @@ export class AgentPool {
 
   /** Persistent per-app agents, keyed by `{monitorId}::{appId}` (see `appKey`). */
   private appAgents = new Map<string, PooledAgent>();
+
+  /**
+   * Persona agents, keyed by `{monitorId}::{appId}::{personaId}` (see `personaAgentKey`).
+   *
+   * Monitor-scoped for the same reason app agents are: the app that spawned them is
+   * itself scoped to the monitor whose window it runs in, so two monitors running the
+   * same app get two independent casts and neither can name the other's.
+   */
+  private personaAgents = new Map<string, PersonaAgent>();
 
   /** Session agent — lazy singleton for cross-monitor oversight. */
   private sessionAgent: PooledAgent | null = null;
@@ -179,8 +232,8 @@ export class AgentPool {
 
   /**
    * Every live agent, exactly once, in the order every caller here reads them:
-   * session → monitor → app → ephemeral. `listAgents()` and `getStats()` expose
-   * that order, so it is part of the contract, not an implementation detail.
+   * session → monitor → app → persona → ephemeral. `listAgents()` and `getStats()`
+   * expose that order, so it is part of the contract, not an implementation detail.
    *
    * The single traversal is the point: a new agent tier is added here and every
    * roster, lookup, and teardown below sees it. They used to walk the four
@@ -191,6 +244,7 @@ export class AgentPool {
     type: AgentEntry['type'];
     monitorId?: string;
     appId?: string;
+    personaId?: string;
   }> {
     if (this.sessionAgent) yield { agent: this.sessionAgent, type: 'session' };
     for (const [monitorId, agent] of this.monitorAgents) {
@@ -198,6 +252,15 @@ export class AgentPool {
     }
     for (const [key, agent] of this.appAgents) {
       yield { agent, type: 'app', ...parseAppKey(key) };
+    }
+    for (const p of this.personaAgents.values()) {
+      yield {
+        agent: p.agent,
+        type: 'persona',
+        monitorId: p.monitorId,
+        appId: p.appId,
+        personaId: p.personaId,
+      };
     }
     for (const agent of this.ephemeralAgents) yield { agent, type: 'ephemeral' };
   }
@@ -462,6 +525,132 @@ export class AgentPool {
     for (const appId of appIds) {
       await this.disposeAppAgent(monitorId, appId);
     }
+
+    // Not folded into the loop above: a persona is spawned by an app's *iframe*,
+    // which needs no app agent to exist. An app that only ever talks to its personas
+    // has entries here and none in `appAgents`, so walking app agents would reclaim
+    // nothing and leak every slot the monitor's personas hold.
+    await this.disposePersonasForMonitor(monitorId);
+  }
+
+  // ── Persona agents ───────────────────────────────────────────────
+
+  /**
+   * Spawn a persona agent for one app on one monitor.
+   *
+   * Returns null when the global limiter has no slot — the caller surfaces that to
+   * the app as a clean "agent limit reached" rather than a crash, since a room of
+   * four characters plus the standing session/monitor/app trio sits close to the
+   * `MAX_AGENTS` default. The per-app cap (`personas.max` in app.json) is checked by
+   * the caller, which is the layer that can read the manifest.
+   */
+  async spawnPersonaAgent(
+    monitorId: string,
+    appId: string,
+    personaId: string,
+    options: { systemPrompt: string; model?: string },
+  ): Promise<PersonaAgent | null> {
+    const provider = await this.acquireProvider();
+    const agent = await this.createAgentCore(provider ?? undefined);
+    if (!agent) {
+      if (provider) await provider.dispose();
+      return null;
+    }
+
+    const record: PersonaAgent = {
+      agent,
+      monitorId,
+      appId,
+      personaId,
+      systemPrompt: options.systemPrompt,
+      ...(options.model ? { model: options.model } : {}),
+      createdAt: Date.now(),
+    };
+    this.personaAgents.set(personaAgentKey(monitorId, appId, personaId), record);
+    console.log(
+      `[AgentPool] Persona "${personaId}" spawned for ${appId} on monitor ${monitorId}: ${agent.instanceId}`,
+    );
+    return record;
+  }
+
+  getPersonaAgent(monitorId: string, appId: string, personaId: string): PersonaAgent | undefined {
+    return this.personaAgents.get(personaAgentKey(monitorId, appId, personaId));
+  }
+
+  /** Every persona one app owns on one monitor, oldest first. */
+  listPersonaAgents(monitorId: string, appId: string): PersonaAgent[] {
+    return [...this.personaAgents.values()]
+      .filter((p) => p.monitorId === monitorId && p.appId === appId)
+      .sort((a, b) => a.createdAt - b.createdAt);
+  }
+
+  /** True while the persona's provider is streaming — one turn at a time per persona. */
+  isPersonaBusy(record: PersonaAgent): boolean {
+    return this.isBusy(record.agent);
+  }
+
+  /**
+   * Run one persona turn, fire and forget.
+   *
+   * Deliberately not routed through `ContextPool`: a persona has no context tape,
+   * no window, and no queue — the app's own scheduler decides who speaks and when,
+   * and the pool's queues exist to serialize things a persona has no share in. What
+   * it does share is the turn machinery, so the answer streams to
+   * `yaar://agents/{instanceId}/stream` exactly like any other agent's, for free.
+   *
+   * The returned promise resolves when the turn ends; callers that want the verb to
+   * return immediately (the app's `message` action does) simply don't await it. The
+   * final text lands on `record.lastResponse` either way.
+   */
+  runPersonaTurn(record: PersonaAgent, content: string, messageId: string): Promise<void> {
+    return record.agent.session.handleMessage(content, {
+      role: personaRole(record.appId, record.personaId),
+      source: monitorSource(record.monitorId),
+      messageId,
+      monitorId: record.monitorId,
+      systemPromptOverride: record.systemPrompt,
+      // The containment. See profiles/persona.ts — an empty allowlist is what stops
+      // a runtime-supplied prompt from reaching a single tool or MCP server.
+      allowedTools: [],
+      ...(record.model ? { model: record.model } : {}),
+      // Not a context tape write — nothing here reaches `ContextTape`. It is the one
+      // callback that hands back the turn's final assistant text, which `read` serves
+      // to an iframe that missed the `done` frame.
+      onContextMessage: (role, text) => {
+        if (role === 'assistant') record.lastResponse = text;
+      },
+    });
+  }
+
+  /** Dispose one persona. Returns false when the app never spawned it. */
+  async disposePersonaAgent(monitorId: string, appId: string, personaId: string): Promise<boolean> {
+    const key = personaAgentKey(monitorId, appId, personaId);
+    const record = this.personaAgents.get(key);
+    if (!record) return false;
+
+    this.personaAgents.delete(key);
+    await this.disposeAgent(
+      record.agent,
+      `Persona "${personaId}" disposed for ${appId} on monitor ${monitorId}`,
+    );
+    return true;
+  }
+
+  /** Dispose every persona one app owns on one monitor. Returns how many died. */
+  async disposePersonasForApp(monitorId: string, appId: string): Promise<number> {
+    const personas = this.listPersonaAgents(monitorId, appId);
+    for (const p of personas) {
+      await this.disposePersonaAgent(monitorId, appId, p.personaId);
+    }
+    return personas.length;
+  }
+
+  /** Dispose every persona on a monitor, whichever app owns it. */
+  async disposePersonasForMonitor(monitorId: string): Promise<void> {
+    const doomed = [...this.personaAgents.values()].filter((p) => p.monitorId === monitorId);
+    for (const p of doomed) {
+      await this.disposePersonaAgent(monitorId, p.appId, p.personaId);
+    }
   }
 
   // ── Session agent ────────────────────────────────────────────────
@@ -555,7 +744,12 @@ export class AgentPool {
     for (const { agent, type } of this.allAgents()) {
       if (agent.instanceId !== agentId) continue;
       // Ephemerals are unprivileged workers spawned by a monitor turn — same tier.
-      return type === 'ephemeral' ? 'monitor' : type;
+      if (type === 'ephemeral') return 'monitor';
+      // Personas are the app tier's own workers. Belt and braces: they run with an
+      // empty tool allowlist, so no MCP request ever arrives carrying one's token,
+      // and if one somehow did it would land in the least-privileged tier there is.
+      if (type === 'persona') return 'app';
+      return type;
     }
     return undefined;
   }
@@ -627,7 +821,7 @@ export class AgentPool {
    */
   listAgents(): AgentEntry[] {
     const entries: AgentEntry[] = [];
-    for (const { agent, type, monitorId, appId } of this.allAgents()) {
+    for (const { agent, type, monitorId, appId, personaId } of this.allAgents()) {
       const id = agent.instanceId;
       const busy = this.isBusy(agent);
       const usage = agent.session.getUsage();
@@ -646,6 +840,18 @@ export class AgentPool {
             busy,
             monitorId,
             appId,
+            usage,
+          });
+          break;
+        case 'persona':
+          entries.push({
+            id,
+            type,
+            label: `${personaId} · ${appId} (monitor ${monitorId})`,
+            busy,
+            monitorId,
+            appId,
+            personaId,
             usage,
           });
           break;
@@ -681,6 +887,7 @@ export class AgentPool {
       busyAgents: busy,
       monitorAgents: this.monitorAgents.size,
       appAgents: this.appAgents.size,
+      personaAgents: this.personaAgents.size,
       ephemeralAgents: this.ephemeralAgents.size,
       sessionAgent: this.sessionAgent !== null,
       usage,
@@ -711,6 +918,7 @@ export class AgentPool {
     this.sessionAgent = null;
     this.monitorAgents.clear();
     this.appAgents.clear();
+    this.personaAgents.clear();
     this.ephemeralAgents.clear();
     for (const id of this.agentIds) {
       getSessionHub().unregisterAgent(id);

--- a/packages/server/src/agents/pool-types.ts
+++ b/packages/server/src/agents/pool-types.ts
@@ -56,6 +56,8 @@ export interface AgentPoolStats {
   busyAgents: number;
   monitorAgents: number;
   appAgents: number;
+  /** Tool-less app-spawned personas, across every app and monitor. */
+  personaAgents: number;
   ephemeralAgents: number;
   sessionAgent: boolean;
   /**

--- a/packages/server/src/agents/profiles/persona.ts
+++ b/packages/server/src/agents/profiles/persona.ts
@@ -1,0 +1,65 @@
+/**
+ * Persona profile — a compute-only agent built from a caller-supplied prompt.
+ *
+ * Every other profile in this directory is an *install-time* artifact: the prompt
+ * comes off disk (`AGENTS.md`, `SKILL.md`) or out of a constant, and the code that
+ * builds it decides what tools the agent gets. A persona inverts the first half —
+ * an app hands in the system prompt at runtime — which is exactly why the second
+ * half is nailed shut here rather than left to the caller.
+ *
+ * `allowedTools: []` is the whole safety story, and it is load-bearing in a way
+ * that is easy to undo by accident. `buildSDKOptions` reads it as an allowlist and
+ * derives the MCP server set from it (`tool.match(/^mcp__(\w+)__/)`), so an empty
+ * list means no MCP servers are even connected, no `WebSearch`, no `Task` — the
+ * process starts with nothing to call. `undefined` would mean the opposite: every
+ * tool YAAR has. A runtime-supplied system prompt must never get hands, so the
+ * empty array is written once, here, and personas are the only tier that has no
+ * way to widen it.
+ *
+ * The `app-` role prefix is the second half of the containment. `assembleSystemPromptForRole`
+ * returns an `app-` prompt verbatim (no environment section, no memory, no scope
+ * blurb), which is what makes the persona *be* its prompt rather than a YAAR agent
+ * wearing one, and `principalRole()` maps it to the unprivileged `app` tier.
+ */
+
+import type { AgentProfile } from './types.js';
+
+/** Max characters of caller-supplied prompt accepted. Generous; a guard, not a budget. */
+export const MAX_PERSONA_PROMPT_CHARS = 20_000;
+
+/** Persona ids are used in URIs, keys, and role strings — keep them boring. */
+export const PERSONA_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/;
+
+/**
+ * The per-turn role string for a persona.
+ *
+ * Must start with `app-`: that prefix is what `assembleSystemPromptForRole` keys
+ * on to leave the prompt alone, and what `principalRole` keys on to place the
+ * turn in the `app` tier. Renaming it silently re-parents the persona into the
+ * monitor tier *and* staples YAAR's environment section onto its prompt.
+ */
+export function personaRole(appId: string, personaId: string): string {
+  return `app-persona-${appId}-${personaId}`;
+}
+
+/**
+ * Build a persona's profile from the prompt its owning app supplied.
+ *
+ * `systemPrompt` is used verbatim — no preamble, no appended house rules. The
+ * caller is an app describing a character; anything appended here leaks YAAR's
+ * voice into it.
+ */
+export function buildPersonaProfile(
+  appId: string,
+  personaId: string,
+  systemPrompt: string,
+  model?: string,
+): AgentProfile {
+  return {
+    id: `persona-${appId}-${personaId}`,
+    description: `Persona "${personaId}" of app ${appId}`,
+    systemPrompt,
+    allowedTools: [],
+    ...(model ? { model } : {}),
+  };
+}

--- a/packages/server/src/agents/session-policies/stream-to-event-mapper.ts
+++ b/packages/server/src/agents/session-policies/stream-to-event-mapper.ts
@@ -223,7 +223,14 @@ export class StreamToEventMapper {
   finish(status: AgentTurnStatus): void {
     if (this.turnClosed) return;
     this.turnClosed = true;
-    this.emitStreamFrame('done', { status });
+    // The turn's final text rides along so a subscriber that only wants the answer
+    // (an app driving a persona) never has to re-read the resource, and one that
+    // accumulated deltas can reconcile against the authoritative string. Present on
+    // an `interrupted` close too — a half-finished answer is still what was said.
+    this.emitStreamFrame('done', {
+      status,
+      ...(this.state.responseText ? { text: this.state.responseText } : {}),
+    });
   }
 
   /** Close the turn with a terminal `error` frame. Same once-only rule as {@link finish}. */

--- a/packages/server/src/agents/window-event-coordinator.ts
+++ b/packages/server/src/agents/window-event-coordinator.ts
@@ -131,7 +131,38 @@ export class WindowEventCoordinator {
           err,
         );
       });
+      this.disposePersonasIfLastWindow(appId, monitorId);
     }
+  }
+
+  /**
+   * Reclaim an app's personas once its last window on this monitor is gone.
+   *
+   * App agents survive a window close — the next window reuses the agent and its
+   * context, which is the behavior a user feels as the app remembering them. Personas
+   * cannot follow that rule: a room of four holds four slots out of the global
+   * `MAX_AGENTS` semaphore, and an app that is no longer on screen holding almost
+   * half the machine's agents starves everything else. The app persists what it needs
+   * (appDb/appStorage) and replays it into a respawned persona's first message, which
+   * is the recovery path the ChitChats port was designed around anyway.
+   *
+   * "Last window" is asked of the window registry rather than the app processor's
+   * `activeWindows`, which tracks the most-recently-active window per app and is
+   * cleared by the close above — reading it here would report "no windows left" while
+   * a second window of the same app is still open.
+   */
+  private disposePersonasIfLastWindow(appId: string, monitorId?: string): void {
+    if (!monitorId) return;
+    const stillOpen = this.ctx.windowState
+      .listWindows()
+      .some(
+        (w) => w.appId === appId && this.ctx.windowState.getMonitorForWindow(w.id) === monitorId,
+      );
+    if (stillOpen) return;
+
+    this.ctx.agentPool.disposePersonasForApp(monitorId, appId).catch((err) => {
+      console.error(`[WindowEventCoordinator] Error disposing personas for ${appId}:`, err);
+    });
   }
 
   /**

--- a/packages/server/src/features/apps/discovery.ts
+++ b/packages/server/src/features/apps/discovery.ts
@@ -339,6 +339,7 @@ export async function getAppMeta(appId: string): Promise<{
   systemApp?: boolean;
   bundles?: string[];
   streams?: string[];
+  personas?: { max: number };
 } | null> {
   const appDir = resolveAppDir(appId);
   if (!appDir) return null;
@@ -359,6 +360,7 @@ export async function getAppMeta(appId: string): Promise<{
       systemApp?: boolean;
       bundles?: string[];
       streams?: string[];
+      personas?: { max: number };
     } = {};
     if (meta.messaging === 'all') result.messaging = 'all';
     // Only bundled apps may be `system` (see readAppInfo) — an installed app
@@ -391,6 +393,20 @@ export async function getAppMeta(appId: string): Promise<{
     if (Array.isArray(meta.streams) && resolveAppSource(appId) === 'bundled') {
       const streams = meta.streams.filter((s: unknown): s is string => typeof s === 'string');
       if (streams.length > 0) result.streams = streams;
+    }
+    // How many tool-less persona agents this app may run per (monitor, app). Absent
+    // or zero means the app cannot spawn any, which is every existing app.
+    //
+    // Bundled-only, mirroring `controls`/`streams`, though a persona is the better
+    // contained of the three: it holds no principal, no tools, and no cross-app
+    // reach. The gate is here because spawning one costs a real provider process and
+    // a slot out of the global `MAX_AGENTS` semaphore — a marketplace app should not
+    // be able to claim four of them by shipping a line of JSON. Read at spawn time
+    // (not carried on the iframe token) because the ceiling is a per-call quota
+    // rather than a capability, and the token is minted once per window.
+    if (meta.personas && resolveAppSource(appId) === 'bundled') {
+      const max = Number(meta.personas.max);
+      if (Number.isInteger(max) && max > 0) result.personas = { max: Math.min(max, 16) };
     }
     // Check for dist/protocol.json to determine appProtocol support
     try {

--- a/packages/server/src/handlers/apps/agents-resource.ts
+++ b/packages/server/src/handlers/apps/agents-resource.ts
@@ -1,0 +1,339 @@
+/**
+ * `yaar://apps/{appId}/agents[/{personaId}]` — an app's own persona agents.
+ *
+ * Reached only through the composite `yaar://apps/*` handler in `register.ts` (the
+ * registry has no middle wildcard). Each entry point returns `null` for a non-persona
+ * URI so the composite can fall through to storage, db, or the app itself.
+ *
+ *   list  ('yaar://apps/self/agents')                                   → roster
+ *   invoke('yaar://apps/self/agents', { action: 'spawn', personaId, systemPrompt, model? })
+ *   invoke('yaar://apps/self/agents/{id}', { action: 'message', content })
+ *   invoke('yaar://apps/self/agents/{id}', { action: 'interrupt' })
+ *   read  ('yaar://apps/self/agents/{id}')                              → status + last answer
+ *   delete('yaar://apps/self/agents/{id}')                              → dispose one
+ *   delete('yaar://apps/self/agents')                                   → dispose all
+ *
+ * ## Ownership
+ *
+ * `self` is resolved to the caller's real appId by the door it came through
+ * (`routes/verb.ts` for an iframe), so by the time a URI reaches here it names a
+ * concrete app — and naming one is not the same as owning it. Every entry point
+ * runs {@link resolveScope}, which requires the appId in the URI to equal the appId
+ * the *context* says the caller is. An app therefore cannot reach another app's
+ * personas even if it declares `yaar://apps/other/agents` in its permissions and
+ * the access chokepoint lets the URI through: the permission list says what you may
+ * ask for, this says whose personas they are.
+ *
+ * A caller with no appId in context — the desktop, an agent turn, anything that is
+ * not an app iframe — owns no personas and is refused outright. That is deliberate
+ * rather than incidental: personas are an app-owned resource with no monitor- or
+ * session-tier equivalent, and there is no principal above them to inherit one.
+ */
+
+import type { VerbResult } from '../uri-registry.js';
+import type { ResolvedUri } from '../uri-resolve.js';
+import { okJson, error, getActivePool, NoActiveSessionError } from '../utils.js';
+import { parseAppAgentsPath } from './paths.js';
+import { getAppId, requireMonitorId } from '../../agents/agent-context.js';
+import { getAppMeta } from '../../features/apps/discovery.js';
+import { buildAgentStreamUri } from '../../streams/agent-stream.js';
+import { MAX_PERSONA_PROMPT_CHARS, PERSONA_ID_RE } from '../../agents/profiles/persona.js';
+import type { AgentPool, PersonaAgent } from '../../agents/agent-pool.js';
+import { genId } from '../../lib/ids.js';
+
+const DESCRIBE = {
+  description:
+    "This app's persona agents — tool-less AI instances with a system prompt you supply at " +
+    'runtime. Each is a real provider session with its own conversation memory, and each ' +
+    'streams token-by-token at yaar://agents/{instanceId}/stream (subscribe with mode:"stream"; ' +
+    'requires "streams": ["agents"] in app.json). Requires "personas": { "max": N } in app.json. ' +
+    'Personas hold no tools, no permissions, and no principal: they receive text and return text.',
+  verbs: ['read', 'list', 'invoke', 'delete'],
+  invokeSchema: {
+    type: 'object',
+    required: ['action'],
+    properties: {
+      action: {
+        type: 'string',
+        enum: ['spawn', 'message', 'interrupt'],
+        description:
+          'spawn (on the collection) creates a persona; message/interrupt address one persona.',
+      },
+      personaId: {
+        type: 'string',
+        description: 'For spawn: the id to register the persona under. [A-Za-z0-9_-], max 64.',
+      },
+      systemPrompt: {
+        type: 'string',
+        description: "For spawn: the persona's system prompt, used verbatim.",
+      },
+      model: { type: 'string', description: 'For spawn: optional model override.' },
+      content: { type: 'string', description: 'For message: the text to send to the persona.' },
+    },
+  },
+};
+
+/** What a persona looks like over the wire. Same shape from `list` and `read`. */
+function personaView(p: PersonaAgent, pool: AgentPool): Record<string, unknown> {
+  return {
+    personaId: p.personaId,
+    instanceId: p.agent.instanceId,
+    streamUri: buildAgentStreamUri(p.agent.instanceId),
+    busy: pool.isPersonaBusy(p),
+    createdAt: p.createdAt,
+    ...(p.model ? { model: p.model } : {}),
+    ...(p.lastResponse !== undefined ? { lastResponse: p.lastResponse } : {}),
+  };
+}
+
+interface Scope {
+  appId: string;
+  personaId?: string;
+  monitorId: string;
+  /**
+   * The pool, resolved on first use rather than up front.
+   *
+   * `getActivePool()` reaches `getActiveSession()`, which *throws* `NoActiveSessionError`
+   * when the hub has no session — and the verb route turns that throw into a retryable
+   * 503, correctly, since an iframe can boot before the desktop's socket connects.
+   * Resolving it eagerly here made every refusal inherit that: a spawn with a malformed
+   * personaId came back as "try again later" instead of "fix the id", and the app dutifully
+   * retried a call that could never succeed. Argument validation now happens first and
+   * answers for itself; only a call that really needs the pool asks for one.
+   */
+  pool: () => AgentPool;
+  /** Per-(monitor, app) ceiling from the manifest. Always > 0 once resolved. */
+  max: number;
+}
+
+/**
+ * Resolve a persona URI to the caller's own scope, or explain why it isn't theirs.
+ *
+ * Returns `null` for a URI this resource does not own (the composite falls through),
+ * a `VerbResult` error for one it owns but the caller may not use, and a {@link Scope}
+ * otherwise.
+ */
+async function resolveScope(uri: string): Promise<Scope | VerbResult | null> {
+  const parsed = parseAppAgentsPath(uri);
+  if (!parsed) return null;
+
+  const callerAppId = getAppId();
+  if (!callerAppId) {
+    return error(
+      'Persona agents are app-owned. This call carries no app identity — it must come from ' +
+        "an app's iframe (POST /api/verb with an iframe token).",
+    );
+  }
+  if (callerAppId !== parsed.appId) {
+    return error(
+      `App "${callerAppId}" cannot reach app "${parsed.appId}"'s personas. Use yaar://apps/self/agents.`,
+    );
+  }
+
+  const meta = await getAppMeta(parsed.appId);
+  const max = meta?.personas?.max ?? 0;
+  if (max <= 0) {
+    return error(
+      `App "${parsed.appId}" may not spawn personas. Add "personas": { "max": N } to its ` +
+        'app.json (bundled apps only).',
+    );
+  }
+
+  return {
+    appId: parsed.appId,
+    ...(parsed.personaId ? { personaId: parsed.personaId } : {}),
+    // The iframe's own window pins the monitor, so a persona is spawned on the desktop
+    // the app is actually running on and can never be addressed from another.
+    monitorId: requireMonitorId(),
+    pool: () => {
+      const pool = getActivePool();
+      if (!pool) throw new NoActiveSessionError();
+      return pool.agentPool;
+    },
+    max,
+  };
+}
+
+/** Narrowing helper — a `VerbResult` came back from `resolveScope` instead of a scope. */
+function isVerbResult(value: Scope | VerbResult): value is VerbResult {
+  return 'content' in value;
+}
+
+/** Look up the addressed persona, or the error explaining that it isn't there. */
+function requirePersona(scope: Scope): PersonaAgent | VerbResult {
+  if (!scope.personaId) {
+    return error('This action addresses one persona: yaar://apps/self/agents/{personaId}.');
+  }
+  const record = scope.pool().getPersonaAgent(scope.monitorId, scope.appId, scope.personaId);
+  if (!record) {
+    return error(
+      `No persona "${scope.personaId}" — spawn it first with ` +
+        `invoke('yaar://apps/self/agents', { action: 'spawn', personaId, systemPrompt }).`,
+    );
+  }
+  return record;
+}
+
+export function describePersonas(uri: string): VerbResult | null {
+  if (!parseAppAgentsPath(uri)) return null;
+  return okJson({ uri, ...DESCRIBE });
+}
+
+export async function listPersonas(resolved: ResolvedUri): Promise<VerbResult | null> {
+  const scope = await resolveScope(resolved.sourceUri);
+  if (scope === null) return null;
+  if (isVerbResult(scope)) return scope;
+
+  const personas = scope.pool().listPersonaAgents(scope.monitorId, scope.appId);
+  return okJson({
+    max: scope.max,
+    personas: personas.map((p) => personaView(p, scope.pool())),
+  });
+}
+
+export async function readPersonas(resolved: ResolvedUri): Promise<VerbResult | null> {
+  const scope = await resolveScope(resolved.sourceUri);
+  if (scope === null) return null;
+  if (isVerbResult(scope)) return scope;
+
+  // A bare collection read is the roster — same answer as `list`, since a caller
+  // reaching for "what personas do I have" shouldn't have to know which verb we
+  // filed it under.
+  if (!scope.personaId) return listPersonas(resolved);
+
+  const record = requirePersona(scope);
+  if ('content' in record) return record;
+  return okJson(personaView(record, scope.pool()));
+}
+
+export async function invokePersonas(
+  resolved: ResolvedUri,
+  payload?: Record<string, unknown>,
+): Promise<VerbResult | null> {
+  const scope = await resolveScope(resolved.sourceUri);
+  if (scope === null) return null;
+  if (isVerbResult(scope)) return scope;
+
+  const action = typeof payload?.action === 'string' ? payload.action : '';
+
+  switch (action) {
+    case 'spawn':
+      return spawn(scope, payload);
+    case 'message':
+      return message(scope, payload);
+    case 'interrupt': {
+      const record = requirePersona(scope);
+      if ('content' in record) return record;
+      await record.agent.session.interrupt();
+      return okJson({ personaId: record.personaId, interrupted: true });
+    }
+    default:
+      return error(`Unknown action "${action}". Use "spawn", "message", or "interrupt".`);
+  }
+}
+
+async function spawn(scope: Scope, payload?: Record<string, unknown>): Promise<VerbResult> {
+  const personaId = typeof payload?.personaId === 'string' ? payload.personaId.trim() : '';
+  const systemPrompt = typeof payload?.systemPrompt === 'string' ? payload.systemPrompt : '';
+  const model = typeof payload?.model === 'string' && payload.model ? payload.model : undefined;
+
+  if (!PERSONA_ID_RE.test(personaId)) {
+    return error(
+      `Invalid personaId "${personaId}". Use letters, digits, "_" or "-" (max 64, must start alphanumeric).`,
+    );
+  }
+  if (!systemPrompt.trim()) {
+    return error('"systemPrompt" is required — it is what makes the persona a persona.');
+  }
+  if (systemPrompt.length > MAX_PERSONA_PROMPT_CHARS) {
+    return error(
+      `"systemPrompt" is ${systemPrompt.length} chars; the limit is ${MAX_PERSONA_PROMPT_CHARS}.`,
+    );
+  }
+
+  // Idempotent by design. An iframe reload re-runs the app's spawn calls, and the
+  // personas from before the reload are still alive with their memory intact — the
+  // right answer is to hand back the ones that exist, not to refuse the app its own
+  // cast or to silently reset four conversations. The prompt is deliberately *not*
+  // updated: it is replayed on every turn, so changing it under a live conversation
+  // would rewrite who the persona has been all along. Delete and respawn to recast.
+  const existing = scope.pool().getPersonaAgent(scope.monitorId, scope.appId, personaId);
+  if (existing) {
+    return okJson({ ...personaView(existing, scope.pool()), reused: true });
+  }
+
+  const live = scope.pool().listPersonaAgents(scope.monitorId, scope.appId).length;
+  if (live >= scope.max) {
+    return error(
+      `Persona limit reached: "${scope.appId}" allows ${scope.max} at a time (${live} live). ` +
+        'Delete one first, or raise "personas".max in app.json.',
+    );
+  }
+
+  const record = await scope.pool().spawnPersonaAgent(scope.monitorId, scope.appId, personaId, {
+    systemPrompt,
+    ...(model ? { model } : {}),
+  });
+  if (!record) {
+    return error(
+      'Agent limit reached — no provider slot is free for a new persona. Close an app window ' +
+        'or delete a persona and try again (raise MAX_AGENTS to make room permanently).',
+    );
+  }
+
+  return okJson(personaView(record, scope.pool()));
+}
+
+async function message(scope: Scope, payload?: Record<string, unknown>): Promise<VerbResult> {
+  const record = requirePersona(scope);
+  if ('content' in record) return record;
+
+  const content = typeof payload?.content === 'string' ? payload.content : '';
+  if (!content.trim()) return error('"content" is required for action "message".');
+
+  // Reject rather than queue. A persona's turns are serialized by whoever schedules
+  // them — the app's own turn loop — and that scheduler is the only thing that knows
+  // whether a second message is a follow-up worth waiting for or a race worth
+  // dropping. Queueing here would decide that for it, invisibly. `busy: true` is on
+  // the envelope so the caller can branch without parsing the sentence.
+  if (scope.pool().isPersonaBusy(record)) {
+    return {
+      ...error(`Persona "${record.personaId}" is still answering. Interrupt it or wait for done.`),
+      structuredContent: { busy: true, personaId: record.personaId },
+    };
+  }
+
+  const taskId = genId('persona');
+  // Not awaited: the answer arrives as stream frames, and the verb returns now so the
+  // app can fire the next persona in the same tick. A rejection here would otherwise
+  // vanish — the turn's own errors reach the caller as `error`/`done` frames, so this
+  // only catches a throw before the stream opens.
+  void scope
+    .pool()
+    .runPersonaTurn(record, content, taskId)
+    .catch((err: unknown) => {
+      console.error(`[personas] turn failed for ${record.appId}/${record.personaId}:`, err);
+    });
+
+  return okJson({
+    taskId,
+    personaId: record.personaId,
+    instanceId: record.agent.instanceId,
+    streamUri: buildAgentStreamUri(record.agent.instanceId),
+  });
+}
+
+export async function deletePersonas(resolved: ResolvedUri): Promise<VerbResult | null> {
+  const scope = await resolveScope(resolved.sourceUri);
+  if (scope === null) return null;
+  if (isVerbResult(scope)) return scope;
+
+  if (!scope.personaId) {
+    const disposed = await scope.pool().disposePersonasForApp(scope.monitorId, scope.appId);
+    return okJson({ disposed });
+  }
+
+  const ok = await scope.pool().disposePersonaAgent(scope.monitorId, scope.appId, scope.personaId);
+  if (!ok) return error(`No persona "${scope.personaId}" to delete.`);
+  return okJson({ personaId: scope.personaId, disposed: 1 });
+}

--- a/packages/server/src/handlers/apps/index.ts
+++ b/packages/server/src/handlers/apps/index.ts
@@ -27,10 +27,18 @@
  *
  * On disk: storage/apps/{appId}/data.db
  *
+ * App-owned persona agents (see docs/proposals/persona_agents_proposal.md):
+ *   list('yaar://apps/self/agents')                              → roster
+ *   invoke('yaar://apps/self/agents', { action: 'spawn', ... })  → spawn a persona
+ *   invoke('yaar://apps/self/agents/{id}', { action, ... })      → message | interrupt
+ *   read('yaar://apps/self/agents/{id}')                         → busy + last answer
+ *   delete('yaar://apps/self/agents[/{id}]')                     → dispose one | all
+ *
  * Structure — `register.ts` owns dispatch order and is the only file that knows the
  * subresources are a composite rather than separate registrations (the registry has
- * no middle wildcard); `app-resource.ts`, `storage-resource.ts`, and `db-resource.ts`
- * own one resource each; `paths.ts` owns URI parsing and the on-disk layout.
+ * no middle wildcard); `app-resource.ts`, `storage-resource.ts`, `db-resource.ts`, and
+ * `agents-resource.ts` own one resource each; `paths.ts` owns URI parsing and the
+ * on-disk layout.
  */
 
 export { registerAppsHandlers } from './register.js';

--- a/packages/server/src/handlers/apps/paths.ts
+++ b/packages/server/src/handlers/apps/paths.ts
@@ -64,6 +64,20 @@ export function parseAppStoragePath(uri: string): { appId: string; path: string 
   return { appId: match[1], path };
 }
 
+/**
+ * Parse `yaar://apps/{appId}/agents[/{personaId}]` → { appId, personaId? } or null.
+ *
+ * The persona id is not validated here — a syntactically fine id that no persona
+ * was spawned under is a 404 from the resource, not a parse failure, and the
+ * resource is where the character set is enforced (`PERSONA_ID_RE`) so the error
+ * can say which rule was broken.
+ */
+export function parseAppAgentsPath(uri: string): { appId: string; personaId?: string } | null {
+  const match = uri.match(/^yaar:\/\/apps\/([^/]+)\/agents(?:\/([^/]+))?\/?$/);
+  if (!match) return null;
+  return { appId: match[1], ...(match[2] ? { personaId: match[2] } : {}) };
+}
+
 /** Parse `yaar://apps/{appId}/db[/{collection}[/{docId}]]` or null. */
 export function parseAppDbPath(
   uri: string,

--- a/packages/server/src/handlers/apps/register.ts
+++ b/packages/server/src/handlers/apps/register.ts
@@ -6,8 +6,8 @@
  * a pattern with a wildcard in the middle, such as `yaar://apps/<wildcard>/storage/...`.
  * So the subresources are *not* independently registered.
  * They are an internal composite behind the single `yaar://apps/*` handler, and each
- * verb below tries them in a fixed order — db, then storage, then the app itself —
- * with each resource module returning `null` for a URI it does not own.
+ * verb below tries them in a fixed order — db, then storage, then agents, then the app
+ * itself — with each resource module returning `null` for a URI it does not own.
  *
  * If the registry ever grows middle wildcards, this composite is the thing to delete;
  * the resource modules are already shaped as independent handlers.
@@ -18,6 +18,13 @@ import type { ResolvedUri } from '../uri-resolve.js';
 import { okJson } from '../utils.js';
 import { parseAppDbPath } from './paths.js';
 import { DB_DESCRIBE, handleDbVerb } from './db-resource.js';
+import {
+  describePersonas,
+  readPersonas,
+  listPersonas,
+  invokePersonas,
+  deletePersonas,
+} from './agents-resource.js';
 import {
   describeStorage,
   readStorage,
@@ -43,7 +50,8 @@ export function registerAppsHandlers(registry: ResourceRegistry): void {
     description:
       'A specific app. Read to load its SKILL.md, invoke to set_badge/install/publish, delete to uninstall. ' +
       'Sub-path /storage/{path} provides app-scoped file storage. ' +
-      'Sub-path /db/{collection} provides app-scoped SQLite collections (Mongo-style filters + full-text search).',
+      'Sub-path /db/{collection} provides app-scoped SQLite collections (Mongo-style filters + full-text search). ' +
+      "Sub-path /agents[/{personaId}] provides the app's own tool-less persona agents.",
     verbs: ['describe', 'read', 'list', 'invoke', 'delete'],
     invokeSchema: {
       type: 'object',
@@ -76,6 +84,9 @@ export function registerAppsHandlers(registry: ResourceRegistry): void {
       const storageResult = describeStorage(resolved.sourceUri);
       if (storageResult) return storageResult;
 
+      const personaResult = describePersonas(resolved.sourceUri);
+      if (personaResult) return personaResult;
+
       return describeApplication(resolved);
     },
 
@@ -85,6 +96,9 @@ export function registerAppsHandlers(registry: ResourceRegistry): void {
 
       const storageResult = await readStorage(resolved);
       if (storageResult) return storageResult;
+
+      const personaResult = await readPersonas(resolved);
+      if (personaResult) return personaResult;
 
       return readApplication(resolved);
     },
@@ -96,6 +110,9 @@ export function registerAppsHandlers(registry: ResourceRegistry): void {
       const storageResult = await listStorage(resolved);
       if (storageResult) return storageResult;
 
+      const personaResult = await listPersonas(resolved);
+      if (personaResult) return personaResult;
+
       return listApplication();
     },
 
@@ -106,6 +123,9 @@ export function registerAppsHandlers(registry: ResourceRegistry): void {
       const storageResult = await invokeStorage(resolved, payload);
       if (storageResult) return storageResult;
 
+      const personaResult = await invokePersonas(resolved, payload);
+      if (personaResult) return personaResult;
+
       return invokeApplication(resolved, payload);
     },
 
@@ -115,6 +135,9 @@ export function registerAppsHandlers(registry: ResourceRegistry): void {
 
       const storageResult = await deleteStorage(resolved);
       if (storageResult) return storageResult;
+
+      const personaResult = await deletePersonas(resolved);
+      if (personaResult) return personaResult;
 
       return deleteApplication(resolved);
     },

--- a/packages/server/src/tests/personas.test.ts
+++ b/packages/server/src/tests/personas.test.ts
@@ -1,0 +1,477 @@
+/**
+ * Persona agents — the app-owned, tool-less agent tier.
+ *
+ * Three properties are worth a test and the rest is plumbing:
+ *
+ * 1. **Tool-lessness.** A persona's system prompt arrives at runtime from an app, so
+ *    the only thing standing between "an app can name a character" and "an app can
+ *    write a prompt that drives the OS" is the empty tool allowlist and what
+ *    `buildSDKOptions` derives from it. Asserted end to end, against the real options
+ *    builder, rather than by reading the profile back.
+ * 2. **Prompt fidelity.** A persona must *be* its prompt — no environment section, no
+ *    memory, no scope blurb — which the `app-` role prefix is what buys.
+ * 3. **Lifecycle.** Spawn, per-app isolation, teardown, and the limiter slots each one
+ *    holds. A leaked persona holds a slot out of a semaphore of ten.
+ *
+ * No `mock.module` here on purpose: `AgentPool` takes its provider factory as a
+ * constructor argument precisely so a test can substitute one without a process-global
+ * stub (see the `acquireProvider` note in agent-pool.ts).
+ */
+import { describe, expect, it, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+import { AgentPool, personaAgentKey } from '../agents/agent-pool.js';
+import {
+  buildPersonaProfile,
+  personaRole,
+  PERSONA_ID_RE,
+  MAX_PERSONA_PROMPT_CHARS,
+} from '../agents/profiles/persona.js';
+import { assembleSystemPromptForRole } from '../agents/system-prompt.js';
+import { principalRole, runWithAgentContext } from '../agents/agent-context.js';
+import {
+  listPersonas,
+  readPersonas,
+  invokePersonas,
+  deletePersonas,
+} from '../handlers/apps/agents-resource.js';
+import type { ResolvedUri } from '../handlers/uri-resolve.js';
+import { buildSDKOptions } from '../providers/claude/sdk-options.js';
+import { initMcpServer } from '../mcp/server.js';
+import { getAppMeta } from '../features/apps/discovery.js';
+import { USER_APPS_DIR } from '../features/apps/roots.js';
+import { parseAppAgentsPath } from '../handlers/apps/paths.js';
+import { getAgentLimiter } from '../agents/limiter.js';
+import type { AITransport, StreamMessage, TransportOptions } from '../providers/types.js';
+import type { SessionId } from '../session/types.js';
+
+// ── A provider that records what it was asked to run ────────────────────────
+
+interface Recorded {
+  prompt: string;
+  options: TransportOptions;
+}
+
+function fakeProvider(recorded: Recorded[]): AITransport {
+  return {
+    name: 'fake',
+    providerType: 'claude',
+    systemPrompt: 'THE GENERIC YAAR PROMPT — a persona must never be handed this.',
+    async isAvailable() {
+      return true;
+    },
+    async *query(prompt: string, options: TransportOptions): AsyncIterable<StreamMessage> {
+      recorded.push({ prompt, options });
+      yield { type: 'text', content: `answer to ${prompt}` } as StreamMessage;
+      yield { type: 'complete' } as StreamMessage;
+    },
+    interrupt() {},
+    async dispose() {},
+  };
+}
+
+// ── Profile ─────────────────────────────────────────────────────────────────
+
+describe('persona profile', () => {
+  it('carries the caller prompt verbatim and no tools at all', () => {
+    const profile = buildPersonaProfile('chitchats', 'alice', 'You are Alice. You are curt.');
+
+    expect(profile.systemPrompt).toBe('You are Alice. You are curt.');
+    expect(profile.allowedTools).toEqual([]);
+    expect(profile.model).toBeUndefined();
+  });
+
+  it('passes a model override through when one is given', () => {
+    const profile = buildPersonaProfile('chitchats', 'bob', 'You are Bob.', 'claude-haiku-4-5');
+    expect(profile.model).toBe('claude-haiku-4-5');
+  });
+
+  it('places the persona in the unprivileged app tier via its role prefix', () => {
+    expect(personaRole('chitchats', 'alice')).toStartWith('app-');
+    expect(principalRole(personaRole('chitchats', 'alice'))).toBe('app');
+  });
+
+  it('assembles the prompt untouched — no environment, memory, or scope section', async () => {
+    const prompt = 'You are Alice. You are curt.';
+    const assembled = await assembleSystemPromptForRole(
+      prompt,
+      personaRole('chitchats', 'alice'),
+      'claude',
+      '0',
+    );
+
+    expect(assembled).toBe(prompt);
+  });
+
+  it('accepts sane persona ids and rejects ids that would break keys or URIs', () => {
+    for (const good of ['alice', 'A1', 'grumpy-pirate', 'x_y-9']) {
+      expect(PERSONA_ID_RE.test(good)).toBe(true);
+    }
+    for (const bad of [
+      '',
+      '-lead',
+      '_lead',
+      'has space',
+      'has/slash',
+      'colon:colon',
+      'a'.repeat(65),
+    ]) {
+      expect(PERSONA_ID_RE.test(bad)).toBe(false);
+    }
+  });
+
+  it('caps the prompt well above any real character sheet', () => {
+    expect(MAX_PERSONA_PROMPT_CHARS).toBeGreaterThan(10_000);
+  });
+});
+
+// ── The containment ─────────────────────────────────────────────────────────
+
+describe('persona tool-lessness (through the real SDK options builder)', () => {
+  // `buildSDKOptions` mints the MCP transport header from the process-global token,
+  // so the builder cannot run before the MCP server has one. Initializing it here
+  // rather than stubbing keeps the assertion pointed at the production path.
+  beforeAll(async () => {
+    await initMcpServer();
+  });
+
+  const optionsFor = (allowedTools?: string[]) =>
+    buildSDKOptions({
+      options: {
+        systemPrompt: 'You are Alice.',
+        agentId: 'agent-1-123',
+        ...(allowedTools ? { allowedTools } : {}),
+      },
+      defaultSystemPrompt: 'generic',
+      abortController: new AbortController(),
+    });
+
+  it('connects no MCP server and enables no builtin tool', () => {
+    const sdk = optionsFor(
+      buildPersonaProfile('chitchats', 'alice', 'You are Alice.').allowedTools,
+    );
+
+    expect(sdk.allowedTools).toEqual([]);
+    expect(sdk.tools).toEqual([]);
+    expect(Object.keys(sdk.mcpServers ?? {})).toEqual([]);
+  });
+
+  it('is the empty array, not the absent one, that closes the door', () => {
+    // The failure mode this guards: dropping `allowedTools` from the persona turn
+    // options (or spelling it `?? undefined`) hands the persona every tool YAAR has.
+    const unfiltered = optionsFor(undefined);
+
+    expect(Object.keys(unfiltered.mcpServers ?? {}).length).toBeGreaterThan(0);
+    expect(unfiltered.tools).toContain('WebSearch');
+  });
+});
+
+// ── URI parsing ─────────────────────────────────────────────────────────────
+
+describe('yaar://apps/{appId}/agents parsing', () => {
+  it('parses the collection and one persona', () => {
+    expect(parseAppAgentsPath('yaar://apps/chitchats/agents')).toEqual({ appId: 'chitchats' });
+    expect(parseAppAgentsPath('yaar://apps/chitchats/agents/alice')).toEqual({
+      appId: 'chitchats',
+      personaId: 'alice',
+    });
+  });
+
+  it('claims no URI belonging to another subresource', () => {
+    expect(parseAppAgentsPath('yaar://apps/chitchats')).toBeNull();
+    expect(parseAppAgentsPath('yaar://apps/chitchats/storage/x.json')).toBeNull();
+    expect(parseAppAgentsPath('yaar://apps/chitchats/db/rooms')).toBeNull();
+    expect(parseAppAgentsPath('yaar://agents/agent-1/stream')).toBeNull();
+    // Nothing nests under a persona — a deeper path is not ours to answer for.
+    expect(parseAppAgentsPath('yaar://apps/chitchats/agents/alice/stream')).toBeNull();
+  });
+});
+
+// ── Lifecycle ───────────────────────────────────────────────────────────────
+
+describe('persona lifecycle in AgentPool', () => {
+  let pool: AgentPool;
+  let recorded: Recorded[];
+  let slotsBefore: number;
+
+  beforeEach(() => {
+    recorded = [];
+    slotsBefore = getAgentLimiter().getCurrentCount();
+    pool = new AgentPool(
+      'ses-personas' as SessionId,
+      () => {},
+      (id) => id,
+      async () => fakeProvider(recorded),
+    );
+  });
+
+  afterEach(async () => {
+    await pool.cleanup();
+  });
+
+  const spawn = (personaId: string, prompt = `You are ${personaId}.`) =>
+    pool.spawnPersonaAgent('0', 'chitchats', personaId, { systemPrompt: prompt });
+
+  it('spawns, finds, and lists personas per (monitor, app)', async () => {
+    const alice = await spawn('alice');
+    const bob = await spawn('bob');
+
+    expect(alice).not.toBeNull();
+    expect(bob).not.toBeNull();
+    expect(alice!.agent.instanceId).not.toBe(bob!.agent.instanceId);
+
+    expect(pool.getPersonaAgent('0', 'chitchats', 'alice')?.systemPrompt).toBe('You are alice.');
+    expect(pool.listPersonaAgents('0', 'chitchats').map((p) => p.personaId)).toEqual([
+      'alice',
+      'bob',
+    ]);
+  });
+
+  it('scopes personas to their app and monitor', async () => {
+    await spawn('alice');
+    await pool.spawnPersonaAgent('1', 'chitchats', 'alice', { systemPrompt: 'monitor one alice' });
+    await pool.spawnPersonaAgent('0', 'other-app', 'alice', { systemPrompt: 'other app alice' });
+
+    // Same persona id, three independent agents — none of them each other.
+    expect(pool.listPersonaAgents('0', 'chitchats')).toHaveLength(1);
+    expect(pool.listPersonaAgents('1', 'chitchats')).toHaveLength(1);
+    expect(pool.listPersonaAgents('0', 'other-app')).toHaveLength(1);
+    expect(pool.getPersonaAgent('0', 'chitchats', 'alice')?.systemPrompt).toBe('You are alice.');
+    expect(pool.getPersonaAgent('1', 'chitchats', 'alice')?.systemPrompt).toBe('monitor one alice');
+    expect(pool.getPersonaAgent('2', 'chitchats', 'alice')).toBeUndefined();
+  });
+
+  it('runs a turn with the persona prompt and an empty tool list', async () => {
+    const alice = await spawn('alice', 'You are Alice. You are curt.');
+    await pool.runPersonaTurn(alice!, 'Bob said hello.', 'task-1');
+
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0].prompt).toBe('Bob said hello.');
+    expect(recorded[0].options.systemPrompt).toBe('You are Alice. You are curt.');
+    expect(recorded[0].options.allowedTools).toEqual([]);
+    // Never the provider's own generic prompt.
+    expect(recorded[0].options.systemPrompt).not.toContain('GENERIC YAAR');
+  });
+
+  it("records the turn's final text for a subscriber that missed the done frame", async () => {
+    const alice = await spawn('alice');
+    expect(alice!.lastResponse).toBeUndefined();
+
+    await pool.runPersonaTurn(alice!, 'question', 'task-1');
+
+    expect(alice!.lastResponse).toBe('answer to question');
+  });
+
+  it('reports personas on the roster with their app, monitor, and persona id', async () => {
+    const alice = await spawn('alice');
+    const entry = pool.listAgents().find((a) => a.id === alice!.agent.instanceId);
+
+    expect(entry?.type).toBe('persona');
+    expect(entry?.appId).toBe('chitchats');
+    expect(entry?.monitorId).toBe('0');
+    expect(entry?.personaId).toBe('alice');
+    expect(pool.getStats().personaAgents).toBe(1);
+    // The roster is what `interruptByIdOrRole` and the monitor lookup read from.
+    expect(pool.hasAgent(alice!.agent.instanceId)).toBe(true);
+    expect(pool.findMonitorForAgent(alice!.agent.instanceId)).toBe('0');
+    // Least-privileged tier, even though a tool call from one is unreachable anyway.
+    expect(pool.getRoleForAgent(alice!.agent.instanceId)).toBe('app');
+  });
+
+  it('releases its limiter slot when disposed', async () => {
+    await spawn('alice');
+    await spawn('bob');
+    expect(getAgentLimiter().getCurrentCount()).toBe(slotsBefore + 2);
+
+    expect(await pool.disposePersonaAgent('0', 'chitchats', 'alice')).toBe(true);
+    expect(getAgentLimiter().getCurrentCount()).toBe(slotsBefore + 1);
+    expect(pool.getPersonaAgent('0', 'chitchats', 'alice')).toBeUndefined();
+
+    // Disposing one that was never spawned is a no-op, not a double release.
+    expect(await pool.disposePersonaAgent('0', 'chitchats', 'alice')).toBe(false);
+    expect(getAgentLimiter().getCurrentCount()).toBe(slotsBefore + 1);
+  });
+
+  it('reclaims a whole cast at once, per app', async () => {
+    await spawn('alice');
+    await spawn('bob');
+    await pool.spawnPersonaAgent('0', 'other-app', 'carol', { systemPrompt: 'carol' });
+
+    expect(await pool.disposePersonasForApp('0', 'chitchats')).toBe(2);
+    expect(pool.listPersonaAgents('0', 'chitchats')).toHaveLength(0);
+    // Another app's personas are not collateral.
+    expect(pool.listPersonaAgents('0', 'other-app')).toHaveLength(1);
+    expect(getAgentLimiter().getCurrentCount()).toBe(slotsBefore + 1);
+  });
+
+  it('reclaims personas when their monitor goes away, with or without an app agent', async () => {
+    // The load-bearing case: an app whose iframe spawned personas but which never
+    // created an app agent. Walking app agents alone would leak every one of these.
+    await spawn('alice');
+    await spawn('bob');
+    expect(pool.getStats().appAgents).toBe(0);
+
+    await pool.disposeAppAgentsForMonitor('0');
+
+    expect(pool.listPersonaAgents('0', 'chitchats')).toHaveLength(0);
+    expect(getAgentLimiter().getCurrentCount()).toBe(slotsBefore);
+  });
+
+  it('releases every slot on pool cleanup', async () => {
+    await spawn('alice');
+    await spawn('bob');
+    await pool.cleanup();
+
+    expect(getAgentLimiter().getCurrentCount()).toBe(slotsBefore);
+    expect(pool.getStats().personaAgents).toBe(0);
+  });
+});
+
+// ── Ownership ───────────────────────────────────────────────────────────────
+
+describe('persona verb ownership', () => {
+  // The handlers read only `sourceUri` off the resolved URI; the composite in
+  // register.ts hands them the whole object, but nothing else is consulted.
+  const uri = (u: string) => ({ sourceUri: u }) as ResolvedUri;
+
+  /** Run as an app iframe would: the appId comes from the token, never the URI. */
+  const asApp = <T>(appId: string, fn: () => T) =>
+    runWithAgentContext(
+      { agentId: `iframe:${appId}`, sessionId: 'ses-x' as SessionId, monitorId: '0', appId },
+      fn,
+    );
+
+  const errorText = (result: { content: Array<{ type: string }>; isError?: boolean }) => {
+    expect(result.isError).toBe(true);
+    const block = result.content[0] as { type: 'text'; text: string };
+    return block.text;
+  };
+
+  it('answers null for a URI that belongs to another subresource', async () => {
+    // The composite falls through on null — claiming a storage URI here would
+    // shadow app storage entirely.
+    expect(await readPersonas(uri('yaar://apps/personas/storage/x.json'))).toBeNull();
+    expect(await invokePersonas(uri('yaar://apps/personas'), { action: 'spawn' })).toBeNull();
+    expect(await deletePersonas(uri('yaar://apps/personas/db/rooms'))).toBeNull();
+  });
+
+  it('refuses a caller that is not an app at all', async () => {
+    // No appId in context: the desktop, an agent turn, a bare HTTP call. Personas
+    // are app-owned and there is no principal above them to inherit one.
+    const result = await listPersonas(uri('yaar://apps/personas/agents'));
+    expect(errorText(result!)).toContain('app-owned');
+  });
+
+  it("refuses an app naming another app's personas", async () => {
+    // The permission list says what a caller may *ask for*; this says whose personas
+    // they are. Both have to agree, and this is the half the app cannot influence.
+    const result = await asApp('memo', () => listPersonas(uri('yaar://apps/personas/agents')));
+    expect(errorText(await result!)).toContain('cannot reach');
+  });
+
+  it('refuses an app that never declared personas, even for its own URI', async () => {
+    const result = await asApp('memo', () => listPersonas(uri('yaar://apps/memo/agents')));
+    expect(errorText(await result!)).toContain('may not spawn personas');
+  });
+
+  it('rejects an unknown action before it can reach the pool', async () => {
+    const result = await asApp('personas', () =>
+      invokePersonas(uri('yaar://apps/personas/agents'), { action: 'summon' }),
+    );
+    expect(errorText(await result!)).toContain('Unknown action');
+  });
+
+  it('rejects a malformed spawn without spending an agent slot', async () => {
+    const slots = getAgentLimiter().getCurrentCount();
+
+    const noPrompt = await asApp('personas', () =>
+      invokePersonas(uri('yaar://apps/personas/agents'), {
+        action: 'spawn',
+        personaId: 'alice',
+      }),
+    );
+    expect(errorText(await noPrompt!)).toContain('systemPrompt');
+
+    const badId = await asApp('personas', () =>
+      invokePersonas(uri('yaar://apps/personas/agents'), {
+        action: 'spawn',
+        personaId: 'not a valid id',
+        systemPrompt: 'You are Alice.',
+      }),
+    );
+    expect(errorText(await badId!)).toContain('Invalid personaId');
+
+    const tooLong = await asApp('personas', () =>
+      invokePersonas(uri('yaar://apps/personas/agents'), {
+        action: 'spawn',
+        personaId: 'alice',
+        systemPrompt: 'x'.repeat(MAX_PERSONA_PROMPT_CHARS + 1),
+      }),
+    );
+    expect(errorText(await tooLong!)).toContain('limit is');
+
+    expect(getAgentLimiter().getCurrentCount()).toBe(slots);
+  });
+});
+
+// ── The manifest gate ───────────────────────────────────────────────────────
+
+describe('personas manifest field', () => {
+  // A real installed app, because the gate is `resolveAppSource(appId) === 'bundled'`
+  // and that reads the filesystem. The point of the rule is that shipping the JSON is
+  // not enough — you have to be in the tree.
+  const INSTALLED_ID = 'persona-gate-fixture';
+  const installedDir = join(USER_APPS_DIR, INSTALLED_ID);
+
+  beforeAll(() => {
+    mkdirSync(installedDir, { recursive: true });
+    writeFileSync(
+      join(installedDir, 'app.json'),
+      JSON.stringify({
+        name: 'Gate Fixture',
+        // Ungated, so the manifest still parses to something — otherwise the gates
+        // strip it to nothing and `getAppMeta` answers null, which would pass the
+        // assertions below for the wrong reason.
+        permissions: ['yaar://apps/self/db/'],
+        personas: { max: 4 },
+        streams: ['agents'],
+      }),
+    );
+  });
+
+  afterAll(() => {
+    rmSync(installedDir, { recursive: true, force: true });
+  });
+
+  it('is honored for a bundled app that declares it', async () => {
+    expect((await getAppMeta('personas'))?.personas).toEqual({ max: 4 });
+  });
+
+  it('is absent for every app that does not declare it', async () => {
+    expect((await getAppMeta('memo'))?.personas).toBeUndefined();
+    expect((await getAppMeta('process-explorer'))?.personas).toBeUndefined();
+  });
+
+  it('is ignored for an installed app, however it spells it', async () => {
+    const meta = await getAppMeta(INSTALLED_ID);
+
+    expect(meta).not.toBeNull();
+    expect(meta?.personas).toBeUndefined();
+    // Same rule as `streams`, and for the same reason — asserted here so the two
+    // gates cannot drift apart unnoticed.
+    expect(meta?.streams).toBeUndefined();
+  });
+});
+
+describe('persona key', () => {
+  it('is unique across all three scoping components', () => {
+    const keys = new Set([
+      personaAgentKey('0', 'chitchats', 'alice'),
+      personaAgentKey('1', 'chitchats', 'alice'),
+      personaAgentKey('0', 'other', 'alice'),
+      personaAgentKey('0', 'chitchats', 'bob'),
+    ]);
+    expect(keys.size).toBe(4);
+  });
+});


### PR DESCRIPTION
Implements Phase 1 of docs/proposals/persona_agents_proposal.md: an app that
declares `"personas": { "max": N }` can spawn up to N AI instances, each with a
system prompt it supplies at runtime, each its own provider session with its own
memory, each streaming into the app's iframe.

Today an app gets exactly one agent, and its prompt is an install-time artifact
read off disk. That is why "several distinct characters answering at once" cannot
be built as an app: firing parallel tasks at one app agent races on AgentSession's
shared turn state, and one context holding N personalities bleeds them together.

The primitive rides machinery that already exists. `AgentSession.handleMessage`
already takes `systemPromptOverride` and `allowedTools`; `StreamToEventMapper`
already publishes every turn to `yaar://agents/{id}/stream`, and `yaar.stream()`
already delivers it into an iframe behind the bundled-only `streams: ["agents"]`
gate. So no provider, frontend, OS Action, or WebSocket change was needed:

- `agents/profiles/persona.ts` — the profile. `allowedTools: []` is the whole
  containment story: `buildSDKOptions` derives the MCP server set from that list,
  so empty means no MCP servers, no WebSearch, no Task — a runtime-supplied prompt
  never gets hands. `undefined` there would mean every tool YAAR has; a test pins
  both halves. The `app-` role prefix is the other half — it makes
  `assembleSystemPromptForRole` return the prompt verbatim and places the turn in
  the unprivileged app tier.
- `agents/agent-pool.ts` — a fifth tier, added at the single `allAgents()`
  traversal so every roster, lookup, and teardown sees it. Monitor-scoped like app
  agents. `runPersonaTurn` bypasses ContextPool deliberately: a persona has no
  tape, no window, and no queue, and the app's own scheduler is what serializes it.
- `handlers/apps/agents-resource.ts` — the verb surface, behind the existing
  `yaar://apps/*` composite. Ownership is not the permission list: the appId in the
  URI must equal the appId the *context* says the caller is, which an app cannot
  forge, so app A cannot reach app B's personas even if it declares the URI.
- `features/apps/discovery.ts` — the manifest field, bundled-only like
  `controls`/`streams`. Spawning costs a real process and a global MAX_AGENTS slot.
- `stream-to-event-mapper.ts` — the `done` frame now carries the turn's final text,
  so a streaming subscriber needs no second round-trip (and an iframe that missed
  the frame can `read` the persona instead).
- `window-event-coordinator.ts` — personas are reclaimed when the app's last window
  on that monitor closes. App agents survive a close because a user feels that as
  the app remembering them; four idle personas holding four of ten slots is a cost
  nobody asked for. "Last window" is asked of the window registry, not
  AppTaskProcessor's activeWindows, which the close itself clears.

Two deltas from the proposal, both recorded in it: `spawn` is idempotent (an
iframe reload must not cost the app its cast, and swapping a live persona's prompt
would rewrite who it has been), and a busy persona rejects rather than queues (only
the app's scheduler knows whether a second message is a follow-up or a race).

`apps/personas` (Round Table) is the proof rather than the ChitChats port: a cast
of characters, all answering one message concurrently with live streaming and a
thinking fold, persisted in appDb. Phases 2/3 — the tape executor, interrupt-weave,
`[[skip]]` convergence — remain unwritten.

29 new tests. Verified end to end against a running YAAR: two personas spawned
through the real UI, roster reported both with their stream URIs, and both turns
entered the provider in the same tick with no MCP wait — the monitor agent on the
same server logged the 5s MCP pending line, the personas logged none.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016T4W76fsvPxdCJW4sm7q2u