### PR TITLE
fix(compiler): the exe never had the mammoth default the types promised

### DIFF
--- a/packages/compiler/CLAUDE.md
+++ b/packages/compiler/CLAUDE.md
@@ -63,6 +63,7 @@ src/
     ├── yaar-web.ts        # Gated SDK: browser automation (requires bundles: ["yaar-web"])
     ├── yaar-ml.ts         # Gated SDK: in-browser model inference via onnxruntime-web (requires bundles: ["yaar-ml"])
     ├── anime.ts           # v3→v4 easing name compat wrapper
+    ├── mammoth.ts         # CommonJS default-export workaround (see below)
     ├── mediabunny.ts      # re-export barrel workaround (see below)
     ├── mermaid.ts         # lazy init, token theming, forced strict mode, serialized renders
     ├── dompurify.ts       # keeps purify.es.mjs off the entrypoint slot (see below)
@@ -341,6 +342,14 @@ header comment with its full rationale — read it before changing or removing o
   does not survive (spurious `EISDIR` on later builds; two days of CI-only failures). The shim
   demotes `purify.es.mjs` to an inner module in both builds; a `prebundle-completeness.test.ts`
   case pins the entrypoint to the shim because the failure reproduces only most of the time.
+- **`mammoth.ts`** — same asymmetry as the barrels, reached through CJS interop: mammoth is
+  CommonJS typed `export = mammoth`, so the default import is the *only* spelling that
+  typechecks, and it is exactly the one the prebundled artifact dropped (named exports only, no
+  `default`). Dev resolves the npm file and Bun synthesizes the default; the exe resolves the
+  artifact and an installed app died with `No matching export in "bundled-lib:mammoth" for import
+  "default"`. **A library's declared default is now probed** — the completeness test derives which
+  libraries promise one from the `.d.ts` and default-imports those artifacts, because a namespace
+  import never asks for `default` and so never saw this.
 
 ## Build Manifest & Staleness
 

--- a/packages/compiler/src/bundled/registry.ts
+++ b/packages/compiler/src/bundled/registry.ts
@@ -28,6 +28,7 @@ export const BUNDLED_SHIMS: Record<string, string> = {
   anime: toForwardSlash(join(SHIMS_DIR, 'anime.ts')),
   dompurify: toForwardSlash(join(SHIMS_DIR, 'dompurify.ts')),
   lodash: toForwardSlash(join(SHIMS_DIR, 'lodash.ts')),
+  mammoth: toForwardSlash(join(SHIMS_DIR, 'mammoth.ts')),
   mediabunny: toForwardSlash(join(SHIMS_DIR, 'mediabunny.ts')),
   mermaid: toForwardSlash(join(SHIMS_DIR, 'mermaid.ts')),
   'pixi.js': toForwardSlash(join(SHIMS_DIR, 'pixi.ts')),

--- a/packages/compiler/src/shims/mammoth.ts
+++ b/packages/compiler/src/shims/mammoth.ts
@@ -1,0 +1,44 @@
+/**
+ * mammoth shim — restores the default export the prebundled artifact loses.
+ *
+ * mammoth is CommonJS (`exports.convertToHtml = …`) and its types are
+ * `export = mammoth`, so the only spelling that typechecks is the default import:
+ *
+ *   import mammoth from '@bundled/mammoth';
+ *
+ * In a repo install that import resolves straight to `mammoth/lib/index.js`, where
+ * Bun's CJS interop synthesizes `default` for it. In the exe it resolves to the
+ * *prebundled* artifact instead — and prebundling the CJS entry emits named
+ * exports only:
+ *
+ *   export{…,rz as convertToMarkdown,oz as convertToHtml,tz as convert}
+ *
+ * so an installed app died at compile time with
+ * `No matching export in "bundled-lib:mammoth" for import "default"`: green in
+ * dev, broken in the release. That asymmetry is the one `uuid.ts` / `zod.ts` /
+ * `lodash.ts` / `pixi.ts` document for barrel libraries, reached by a different
+ * route — CJS interop rather than a dropped re-export.
+ *
+ * Routing through this shim makes mammoth an inner module whose default the
+ * bundler re-exports for real, in either environment. The named half is not in
+ * the declared type surface; it is kept because it is what the artifact already
+ * exported, and an app written against the broken release may be using it.
+ */
+import mammoth from 'mammoth';
+
+/**
+ * mammoth's `.d.ts` describes four of the ten members its CJS module exports.
+ * The four keep their real types; the rest are reached through this widened view
+ * rather than being dropped from a surface the artifact already carried.
+ */
+const api = mammoth as typeof mammoth & Record<string, unknown>;
+
+export default mammoth;
+
+export const { convertToHtml, extractRawText, embedStyleMap, images } = mammoth;
+export const convert = api.convert;
+export const convertToMarkdown = api.convertToMarkdown;
+export const readEmbeddedStyleMap = api.readEmbeddedStyleMap;
+export const styleMapping = api.styleMapping;
+export const transforms = api.transforms;
+export const underline = api.underline;

--- a/packages/compiler/src/tests/prebundle-completeness.test.ts
+++ b/packages/compiler/src/tests/prebundle-completeness.test.ts
@@ -14,8 +14,18 @@
  * then compile a consumer against the artifact — and asserting the consumer
  * builds. A dropped binding surfaces here as a failed consumer compile, at test
  * time, for the specific library, instead of at install time in the field.
+ *
+ * The consumer imports the artifact the way an app is *allowed* to: a namespace
+ * import always, plus a default import for every library whose `.d.ts` block
+ * declares one. The default half was added after `@bundled/mammoth` — CommonJS,
+ * typed `export = mammoth` — shipped an artifact with named exports and no
+ * default, so `import mammoth from '@bundled/mammoth'` typechecked, compiled in
+ * dev, and failed at install time against the release with `No matching export
+ * in "bundled-lib:mammoth" for import "default"`. A namespace import never asks
+ * for `default`, so this test passed the whole time.
  */
 import { describe, expect, setDefaultTimeout, test } from 'bun:test';
+import { readFileSync } from 'fs';
 import { mkdtemp, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -26,6 +36,25 @@ import {
   resolvePrebundleEntrypoint,
   toForwardSlash,
 } from '../index.js';
+import { BUNDLED_TYPES_DTS } from '../paths.js';
+
+const DTS = readFileSync(BUNDLED_TYPES_DTS, 'utf-8');
+
+/**
+ * Does `declare module '@bundled/<name>'` promise a default export?
+ *
+ * Derived from the `.d.ts` rather than listed here, so a library that gains or
+ * loses a default is probed accordingly without anyone remembering to say so.
+ * The block is matched by exact module name (never a `/…` subpath): `solid-js`
+ * has no default of its own, `solid-js/html` does.
+ */
+function declaresDefaultExport(name: string): boolean {
+  const start = DTS.indexOf(`declare module '@bundled/${name}' {`);
+  if (start === -1) return false;
+  const next = DTS.indexOf(`\ndeclare module '`, start + 1);
+  const block = DTS.slice(start, next === -1 ? undefined : next);
+  return /^\s*export\s+(default\b|=|\{[^}]*\bdefault\b)/m.test(block);
+}
 
 // Each case pays for a real prebundle (some libraries are megabytes) plus a
 // consumer Bun.build(). Big libs (mermaid, three, mammoth) dominate the cost.
@@ -52,11 +81,17 @@ describe('prebundle completeness', () => {
         // list; referencing `lib` keeps it from being tree-shaken away. If any
         // export references a dropped/renamed identifier, this build fails with
         // `"<id>" is not declared in this file` — exactly the field failure.
+        // A library whose type surface promises a default is imported both ways,
+        // because only the default import fails when the default is missing.
+        const spec = JSON.stringify(toForwardSlash(artifact));
+        const wantsDefault = declaresDefaultExport(name);
         const consumer = join(dir, 'consumer.ts');
         await Bun.write(
           consumer,
-          `import * as lib from ${JSON.stringify(toForwardSlash(artifact))};\n` +
-            `(globalThis as Record<string, unknown>).__probe = lib;\n`,
+          `import * as lib from ${spec};\n` +
+            (wantsDefault ? `import def from ${spec};\n` : '') +
+            `(globalThis as Record<string, unknown>).__probe = ` +
+            `${wantsDefault ? '[lib, def]' : 'lib'};\n`,
         );
 
         const result = await Bun.build({


### PR DESCRIPTION
`@bundled/mammoth` is CommonJS, typed `export = mammoth`, so the default import is the only spelling that typechecks:

```ts
import mammoth from '@bundled/mammoth';
```

A repo install resolves that to `mammoth/lib/index.js` and Bun's CJS interop synthesizes `default`. The exe resolves it to the *prebundled* artifact instead, whose only export statement is named:

```
export{…,rz as convertToMarkdown,oz as convertToHtml,tz as convert}
```

So installing an app that imported mammoth failed against the release with:

```
No matching export in "bundled-lib:mammoth" for import "default"
```

Green in dev, broken in the release — the same asymmetry `uuid.ts` / `zod.ts` / `lodash.ts` / `pixi.ts` document for barrel libraries, reached by a different route.

## What changed

- **`shims/mammoth.ts`** (new, registered in `BUNDLED_SHIMS`) — makes mammoth an inner module whose default the bundler re-exports for real, in both environments. The named half is kept: it is not in the declared type surface, but it is what the artifact already exported, so an app written against the broken release keeps working.
- **`prebundle-completeness.test.ts`** — the test never asked for a default. It probes with `import * as lib`, which resolves whether or not a `default` exists, so this shipped with every signal green. It now derives from `bundled-types/index.d.ts` which libraries promise a default (`solid-js/html`, `dompurify`, `matter-js`, `mammoth`, `mermaid`, `yaar`) and default-imports those artifacts too. Reverting the shim reproduces the field error inside the test.
- **`packages/compiler/CLAUDE.md`** — records the shim and the widened probe.

## Verification

- Reverting the registry line makes `@bundled/mammoth: prebundled artifact's exports all resolve` fail with the exact field error; with the shim, mammoth was the only one of the six default-declaring libraries that had been broken.
- `bun test packages/compiler/src/tests/prebundle-completeness.test.ts` — 30 pass.
- `bun run --filter @yaar/compiler test` — 288 pass.
- `bun run typecheck`, `bun run lint`, `bun run format:check` — clean.
- App-shaped consumer compiled through `bundledLibraryPluginBun()` with both the default and a named import: OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
