### PR TITLE
release: set version to 0.15.0

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -37,7 +37,7 @@ Windows (PowerShell): `irm https://github.com/sorryhyun/yaar/releases/latest/dow
 
 **특정 버전 / 설치 경로 변경:**
 ```bash
-VERSION=v0.14.0 curl -fsSL ... | bash    # 특정 버전 (기본: 최신)
+VERSION=v0.15.0 curl -fsSL ... | bash    # 특정 버전 (기본: 최신)
 INSTALL_DIR=/usr/local/bin curl -fsSL ... | bash  # 설치 경로 (기본: ~/.local/bin)
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Once running, start with something like "install essential apps".
 
 **Pin a version / custom install path:**
 ```bash
-VERSION=v0.14.0 curl -fsSL ... | bash             # Specific version (default: latest)
+VERSION=v0.15.0 curl -fsSL ... | bash             # Specific version (default: latest)
 INSTALL_DIR=/usr/local/bin curl -fsSL ... | bash  # Install path (default: ~/.local/bin)
 ```
 

--- a/docs/reference/openapi.yaml
+++ b/docs/reference/openapi.yaml
@@ -2,7 +2,7 @@ openapi: '3.1.0'
 info:
   title: YAAR Server API
   description: REST API for the YAAR reactive AI interface server.
-  version: 0.14.0
+  version: 0.15.0
 servers:
   - url: http://localhost:8000
     description: Local development server

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yaar",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "description": "Reactive AI interface where the AI decides what to show and do next",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yaar/compiler",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yaar/frontend",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yaar/server",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "description": "YAAR TypeScript backend with Claude Agent SDK",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yaar/shared",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Follow-up to #68, which merged at `a0f6190e` — one commit before the version
bump landed on `dev`. `main` is therefore still stamped 0.14.0, and
`release.yml` asserts the target commit's version matches the tag, so the
v0.15.0 draft cannot be cut until this is on `main`.

Version-only diff across 8 files: both READMEs' `VERSION=` pin examples,
`openapi.yaml`'s `info.version`, and the four package manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)